### PR TITLE
feat: Semantic search endpoint + API refactor

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -10,9 +10,8 @@ import os
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
-import api.state as _app_state
 from api.questions import router as questions_router
-from api.state import ALBERT_BASE_URL, ALBERT_RERANK_MODEL, AppState
+from api.state import ALBERT_BASE_URL, ALBERT_RERANK_MODEL, AppState, set_state
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from qe.clients.qdrant import QdrantClient
@@ -28,16 +27,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     qdrant_url = os.environ.get("QDRANT_URL", "http://localhost:6333")
 
-    _app_state._state = AppState(
-        qdrant=QdrantClient(qdrant_url),
-        reranker=RerankClient(
-            base_url=ALBERT_BASE_URL,
-            model=ALBERT_RERANK_MODEL,
-            api_key=albert_api_key,
-        ),
+    set_state(
+        AppState(
+            qdrant=QdrantClient(qdrant_url),
+            reranker=RerankClient(
+                base_url=ALBERT_BASE_URL,
+                model=ALBERT_RERANK_MODEL,
+                api_key=albert_api_key,
+            ),
+        )
     )
     yield
-    _app_state._state = None
+    set_state(None)
 
 
 app = FastAPI(

--- a/api/main.py
+++ b/api/main.py
@@ -2,70 +2,33 @@
 
 Start with:
     poetry run uvicorn api.main:app --reload
-
-Endpoints
----------
-GET /api/questions/{question_id}/attributions
-    Return the top-N ranked offices for a question that is already embedded
-    in the ``questions_opendata`` Qdrant collection.  The question's vector is
-    fetched directly from Qdrant — no call to the Socle IA embedding service
-    is made.  Only the Albert reranker is called.
 """
 
 from __future__ import annotations
 
-import math
 import os
-import statistics
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
 from typing import AsyncIterator
 
-from fastapi import FastAPI, HTTPException
+import api.state as _app_state
+from api.questions import router as questions_router
+from api.state import ALBERT_BASE_URL, ALBERT_RERANK_MODEL, AppState
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-
-from qe.assignment import aggregate_matches, build_matches, retrieve_candidates
 from qe.clients.qdrant import QdrantClient
 from qe.clients.rerank import RerankClient
-from qe.hashing import stable_question_point_id
-from qe.office_ingestion import OFFICE_COLLECTION
-
-QUESTIONS_COLLECTION = "questions_opendata"
-ALBERT_BASE_URL = "https://albert.api.etalab.gouv.fr"
-ALBERT_RERANK_MODEL = "openweight-rerank"
-
-# ---------------------------------------------------------------------------
-# Shared client state (initialised once at startup)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class AppState:
-    qdrant: QdrantClient
-    reranker: RerankClient
-
-
-_state: AppState | None = None
-
-
-def _get_state() -> AppState:
-    if _state is None:
-        raise RuntimeError("Application has not started yet.")
-    return _state
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Initialise shared clients on startup, release on shutdown."""
-    global _state
-
     albert_api_key = os.environ.get("ALBERT_API_KEY", "")
     if not albert_api_key:
         raise RuntimeError("ALBERT_API_KEY environment variable is not set.")
 
     qdrant_url = os.environ.get("QDRANT_URL", "http://localhost:6333")
 
-    _state = AppState(
+    _app_state._state = AppState(
         qdrant=QdrantClient(qdrant_url),
         reranker=RerankClient(
             base_url=ALBERT_BASE_URL,
@@ -74,12 +37,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         ),
     )
     yield
-    _state = None
+    _app_state._state = None
 
-
-# ---------------------------------------------------------------------------
-# App
-# ---------------------------------------------------------------------------
 
 app = FastAPI(
     title="QE Attribution API",
@@ -95,162 +54,4 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _to_relevance(agg_score: float, pool_scores: list[float]) -> float:
-    """Relevance of an office for a question, as a percentage.
-
-    ``agg_score`` is the sum of the Albert reranker scores across the top-2
-    chunks for this office (responsibilities + keywords).  Using the aggregate
-    rather than just the best chunk avoids identical relevance values when
-    multiple offices tie on their highest-scoring chunk (a common occurrence).
-
-    Blends two signals:
-
-    - **Absolute** (70 %): ``sigmoid(agg_score) × 100`` — the model's raw
-      judgment about how relevant the question is to this office, regardless
-      of what other offices were retrieved.
-
-    - **Relative** (30 %): a pool-median-centred linear adjustment — each
-      unit above the pool median adds ~6 pp; each unit below subtracts ~6 pp.
-      This makes real score gaps between the top offices visible without
-      distorting the absolute meaning.
-
-    The blend satisfies both constraints:
-    - Tightly clustered raw scores → nearly identical relevance values.
-    - Well-separated raw scores → the gap is visible in the output.
-
-    Returns a float in [0.0, 100.0], rounded to one decimal place.
-    """
-    absolute = 100.0 / (1.0 + math.exp(-agg_score))
-
-    if len(pool_scores) < 2:
-        return round(absolute, 1)
-
-    median_score = statistics.median(pool_scores)
-    median_abs = 100.0 / (1.0 + math.exp(-median_score))
-
-    # Linear relative component: each unit of deviation from the pool median
-    # maps to PP_PER_UNIT percentage points.  Clamped to [0, 100].
-    PP_PER_UNIT = 20.0
-    relative = median_abs + (agg_score - median_score) * PP_PER_UNIT
-    relative = max(0.0, min(100.0, relative))
-
-    # 30 % relative weight → effective contribution: 0.3 × 20 = 6 pp per logit.
-    return round(0.7 * absolute + 0.3 * relative, 1)
-
-
-# ---------------------------------------------------------------------------
-# Routes
-# ---------------------------------------------------------------------------
-
-
-@app.get("/api/questions/{question_id}/attributions")
-def get_attributions(question_id: str, top_k: int = 3) -> dict:
-    """Return the top-N office attribution suggestions for a question.
-
-    The question must already be embedded in the ``questions_opendata``
-    collection.  Its stored vector is used directly for the office search
-    so no embedding API call is required.
-
-    Args:
-        question_id: Composite question ID, e.g. ``AN-17-QE-12345``.
-        top_k: Number of office suggestions to return (default 3).
-
-    Returns:
-        A dict with ``question_id`` and an ``attributions`` list sorted by
-        descending relevance, each entry containing ``rank``, ``office_id``,
-        ``office_name``, ``direction``, ``score``, and ``relevance``.
-
-    Raises:
-        404: Question point not found in Qdrant (not yet embedded).
-        422: ``top_k`` is less than 1.
-    """
-    if top_k < 1:
-        raise HTTPException(status_code=422, detail="top_k must be at least 1.")
-
-    state = _get_state()
-
-    # 1. Fetch the question's pre-computed vector and text from Qdrant.
-    point_id = stable_question_point_id(question_id)
-    point = state.qdrant.get_point(QUESTIONS_COLLECTION, point_id, with_vectors=True)
-    if point is None:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Question '{question_id}' not found in Qdrant. "
-            "Make sure it has been embedded with scripts/embed_questions.py.",
-        )
-
-    vector: list[float] = point["vector"]
-    payload = point.get("payload") or {}
-    texte_question: str = payload.get("texte_question") or ""
-
-    if not texte_question:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Question '{question_id}' has no texte_question in its Qdrant payload.",
-        )
-
-    # 2. Search the office_responsibilities collection using the stored vector
-    #    (no embedding call needed).
-    candidates = retrieve_candidates(
-        precomputed_vectors=[vector],
-        qdrant=state.qdrant,
-        collection=OFFICE_COLLECTION,
-        top_k=20,
-    )
-
-    # 3. Rerank candidates against the question text.
-    matches = build_matches(
-        candidates=candidates,
-        reranker=state.reranker,
-        query=texte_question,
-    )
-
-    # 4. Aggregate per-office scores and rank.
-    kept_matches, score_by_office = aggregate_matches(matches, max_chunks_per_office=2)
-
-    # 5. Deduplicate to one entry per office and return the top_k.
-    #
-    # Use the aggregated per-office score (sum of top-2 chunk scores) as the
-    # relevance signal.  Using the individual best-chunk score instead causes
-    # identical relevance values whenever multiple offices tie on their top
-    # chunk — which is common because the reranker often assigns the same score
-    # to the highest-ranked chunk across the top-3 offices.  The aggregated
-    # score captures both chunks and is already unique per office.
-    pool_scores = list(score_by_office.values())
-
-    # Build a metadata lookup (office_name, direction) from kept_matches.
-    # kept_matches is sorted by individual chunk score, which can disagree with
-    # the aggregated score_by_office ranking when an office's second chunk is
-    # strong.  Iterating kept_matches directly would produce attributions whose
-    # rank order contradicts their relevance values, so we drive the final loop
-    # from score_by_office (sorted descending) instead.
-    office_meta: dict[str, dict] = {}
-    for m in kept_matches:
-        oid = m.get("office_id")
-        if oid and oid not in office_meta:
-            office_meta[oid] = m
-
-    attributions: list[dict] = []
-    for office_id, agg_score in sorted(score_by_office.items(), key=lambda x: -x[1]):
-        meta = office_meta.get(office_id)
-        if not meta:
-            continue
-        attributions.append(
-            {
-                "rank": len(attributions) + 1,
-                "office_id": office_id,
-                "office_name": meta.get("office_name"),
-                "direction": meta.get("direction"),
-                "score": round(agg_score, 4),
-                "relevance": _to_relevance(agg_score, pool_scores),
-            }
-        )
-        if len(attributions) >= top_k:
-            break
-
-    return {"question_id": question_id, "attributions": attributions}
+app.include_router(questions_router)

--- a/api/questions.py
+++ b/api/questions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import statistics
 
@@ -18,6 +19,8 @@ from qe.office_ingestion import OFFICE_COLLECTION
 
 from api.state import _get_state
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/questions", tags=["questions"])
 
 QUESTIONS_COLLECTION = "questions_opendata"
@@ -32,6 +35,25 @@ _SIMILAR_COLLECTIONS: dict[str, tuple[str, str, str | None]] = {
     "answers": (ANSWERS_COLLECTION, "texte_reponse", None),
     "offices": (OFFICE_COLLECTION, "text", "office_id"),
 }
+
+
+def _dedup_by_key(
+    scored: list[tuple[dict, float]], dedup_key: str
+) -> list[tuple[dict, float]]:
+    """Keep the highest-scoring hit per unique value of ``dedup_key`` in payload."""
+    seen: dict[str, tuple[dict, float]] = {}
+    for candidate, score in scored:
+        key = (candidate.get("payload") or {}).get(dedup_key)
+        if key is None:
+            logger.warning(
+                "Chunk %s is missing payload field '%s'; skipping.",
+                candidate.get("id"),
+                dedup_key,
+            )
+            continue
+        if key not in seen or score > seen[key][1]:
+            seen[key] = (candidate, score)
+    return sorted(seen.values(), key=lambda x: -x[1])
 
 
 def _to_relevance(agg_score: float, pool_scores: list[float]) -> float:
@@ -224,6 +246,10 @@ def get_similar(
         )
     if not (1 <= top_k <= 50):
         raise HTTPException(status_code=422, detail="top_k must be between 1 and 50.")
+    if score_threshold is not None and not (0.0 <= score_threshold <= 1.0):
+        raise HTTPException(
+            status_code=422, detail="score_threshold must be between 0.0 and 1.0."
+        )
 
     state = _get_state()
     target_collection, text_field, dedup_key = _SIMILAR_COLLECTIONS[collection]
@@ -270,14 +296,7 @@ def get_similar(
     # For collections with multiple chunks per entity (offices), keep only the
     # best-scoring chunk per entity so each office appears at most once.
     if dedup_key is not None:
-        seen: dict[str, tuple[dict, float]] = {}
-        for candidate, score in scored:
-            key = (candidate.get("payload") or {}).get(dedup_key)
-            if key is None:
-                continue
-            if key not in seen or score > seen[key][1]:
-                seen[key] = (candidate, score)
-        scored = sorted(seen.values(), key=lambda x: -x[1])
+        scored = _dedup_by_key(scored, dedup_key)
 
     hits = [
         {

--- a/api/questions.py
+++ b/api/questions.py
@@ -1,0 +1,291 @@
+"""Routes for /api/questions/* endpoints."""
+
+from __future__ import annotations
+
+import math
+import statistics
+
+from fastapi import APIRouter, HTTPException
+
+from qe.assignment import (
+    aggregate_matches,
+    build_matches,
+    rerank_candidates,
+    retrieve_candidates,
+)
+from qe.hashing import stable_question_point_id
+from qe.office_ingestion import OFFICE_COLLECTION
+
+from api.state import _get_state
+
+router = APIRouter(prefix="/api/questions", tags=["questions"])
+
+QUESTIONS_COLLECTION = "questions_opendata"
+ANSWERS_COLLECTION = "answers_opendata"
+
+# Allowlisted collections for the /similar endpoint.
+# Maps the public name to (internal_collection, text_field, dedup_key).
+# dedup_key=None means one Qdrant point per entity (no deduplication needed).
+# dedup_key="office_id" means keep only the best-scoring chunk per office.
+_SIMILAR_COLLECTIONS: dict[str, tuple[str, str, str | None]] = {
+    "questions": (QUESTIONS_COLLECTION, "texte_question", None),
+    "answers": (ANSWERS_COLLECTION, "texte_reponse", None),
+    "offices": (OFFICE_COLLECTION, "text", "office_id"),
+}
+
+
+def _to_relevance(agg_score: float, pool_scores: list[float]) -> float:
+    """Relevance of an office for a question, as a percentage.
+
+    ``agg_score`` is the sum of the Albert reranker scores across the top-2
+    chunks for this office (responsibilities + keywords).  Using the aggregate
+    rather than just the best chunk avoids identical relevance values when
+    multiple offices tie on their highest-scoring chunk (a common occurrence).
+
+    Blends two signals:
+
+    - **Absolute** (70 %): ``sigmoid(agg_score) × 100`` — the model's raw
+      judgment about how relevant the question is to this office, regardless
+      of what other offices were retrieved.
+
+    - **Relative** (30 %): a pool-median-centred linear adjustment — each
+      unit above the pool median adds ~6 pp; each unit below subtracts ~6 pp.
+      This makes real score gaps between the top offices visible without
+      distorting the absolute meaning.
+
+    The blend satisfies both constraints:
+    - Tightly clustered raw scores → nearly identical relevance values.
+    - Well-separated raw scores → the gap is visible in the output.
+
+    Returns a float in [0.0, 100.0], rounded to one decimal place.
+    """
+    absolute = 100.0 / (1.0 + math.exp(-agg_score))
+
+    if len(pool_scores) < 2:
+        return round(absolute, 1)
+
+    median_score = statistics.median(pool_scores)
+    median_abs = 100.0 / (1.0 + math.exp(-median_score))
+
+    # Linear relative component: each unit of deviation from the pool median
+    # maps to PP_PER_UNIT percentage points.  Clamped to [0, 100].
+    PP_PER_UNIT = 20.0
+    relative = median_abs + (agg_score - median_score) * PP_PER_UNIT
+    relative = max(0.0, min(100.0, relative))
+
+    # 30 % relative weight → effective contribution: 0.3 × 20 = 6 pp per logit.
+    return round(0.7 * absolute + 0.3 * relative, 1)
+
+
+@router.get("/{question_id}/attributions")
+def get_attributions(question_id: str, top_k: int = 3) -> dict:
+    """Return the top-N office attribution suggestions for a question.
+
+    The question must already be embedded in the ``questions_opendata``
+    collection.  Its stored vector is used directly for the office search
+    so no embedding API call is required.
+
+    Args:
+        question_id: Composite question ID, e.g. ``AN-17-QE-12345``.
+        top_k: Number of office suggestions to return (default 3).
+
+    Returns:
+        A dict with ``question_id`` and an ``attributions`` list sorted by
+        descending relevance, each entry containing ``rank``, ``office_id``,
+        ``office_name``, ``direction``, ``score``, and ``relevance``.
+
+    Raises:
+        404: Question point not found in Qdrant (not yet embedded).
+        422: ``top_k`` is less than 1.
+    """
+    if top_k < 1:
+        raise HTTPException(status_code=422, detail="top_k must be at least 1.")
+
+    state = _get_state()
+
+    # 1. Fetch the question's pre-computed vector and text from Qdrant.
+    point_id = stable_question_point_id(question_id)
+    point = state.qdrant.get_point(QUESTIONS_COLLECTION, point_id, with_vectors=True)
+    if point is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Question '{question_id}' not found in Qdrant. "
+            "Make sure it has been embedded with scripts/embed_questions.py.",
+        )
+
+    vector: list[float] = point["vector"]
+    payload = point.get("payload") or {}
+    texte_question: str = payload.get("texte_question") or ""
+
+    if not texte_question:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Question '{question_id}' has no texte_question in its Qdrant payload.",
+        )
+
+    # 2. Search the office_responsibilities collection using the stored vector
+    #    (no embedding call needed).
+    candidates = retrieve_candidates(
+        precomputed_vectors=[vector],
+        qdrant=state.qdrant,
+        collection=OFFICE_COLLECTION,
+        top_k=20,
+    )
+
+    # 3. Rerank candidates against the question text.
+    matches = build_matches(
+        candidates=candidates,
+        reranker=state.reranker,
+        query=texte_question,
+    )
+
+    # 4. Aggregate per-office scores and rank.
+    kept_matches, score_by_office = aggregate_matches(matches, max_chunks_per_office=2)
+
+    # 5. Deduplicate to one entry per office and return the top_k.
+    #
+    # Use the aggregated per-office score (sum of top-2 chunk scores) as the
+    # relevance signal.  Using the individual best-chunk score instead causes
+    # identical relevance values whenever multiple offices tie on their top
+    # chunk — which is common because the reranker often assigns the same score
+    # to the highest-ranked chunk across the top-3 offices.  The aggregated
+    # score captures both chunks and is already unique per office.
+    pool_scores = list(score_by_office.values())
+
+    # Build a metadata lookup (office_name, direction) from kept_matches.
+    # kept_matches is sorted by individual chunk score, which can disagree with
+    # the aggregated score_by_office ranking when an office's second chunk is
+    # strong.  Iterating kept_matches directly would produce attributions whose
+    # rank order contradicts their relevance values, so we drive the final loop
+    # from score_by_office (sorted descending) instead.
+    office_meta: dict[str, dict] = {}
+    for m in kept_matches:
+        oid = m.get("office_id")
+        if oid and oid not in office_meta:
+            office_meta[oid] = m
+
+    attributions: list[dict] = []
+    for office_id, agg_score in sorted(score_by_office.items(), key=lambda x: -x[1]):
+        meta = office_meta.get(office_id)
+        if not meta:
+            continue
+        attributions.append(
+            {
+                "rank": len(attributions) + 1,
+                "office_id": office_id,
+                "office_name": meta.get("office_name"),
+                "direction": meta.get("direction"),
+                "score": round(agg_score, 4),
+                "relevance": _to_relevance(agg_score, pool_scores),
+            }
+        )
+        if len(attributions) >= top_k:
+            break
+
+    return {"question_id": question_id, "attributions": attributions}
+
+
+@router.get("/{question_id}/similar")
+def get_similar(
+    question_id: str,
+    collection: str,
+    top_k: int = 10,
+    score_threshold: float | None = None,
+) -> dict:
+    """Return semantically similar items from a Qdrant collection.
+
+    The source question must already be embedded in ``questions_opendata``.
+    Its stored vector is used directly — no embedding API call is made.
+    Results are reranked with Albert before being returned.
+
+    Args:
+        question_id: Composite question ID, e.g. ``AN-17-QE-12345``.
+        collection: Target collection — one of ``questions``, ``answers``,
+            ``offices``.
+        top_k: Number of results to return (default 10, max 50).
+        score_threshold: Optional minimum cosine similarity (0.0–1.0) applied
+            before reranking to drop clearly irrelevant candidates.
+
+    Returns:
+        A dict with ``question_id``, ``collection``, and a ``hits`` list sorted
+        by descending rerank score.  Each hit has ``id``, ``score``, and
+        ``payload`` (collection-specific fields passed through from Qdrant).
+
+    Raises:
+        404: Question not found in Qdrant (not yet embedded).
+        422: ``collection`` is not one of the allowed values, or ``top_k``
+            is out of range.
+    """
+    if collection not in _SIMILAR_COLLECTIONS:
+        allowed = ", ".join(sorted(_SIMILAR_COLLECTIONS))
+        raise HTTPException(
+            status_code=422,
+            detail=f"collection must be one of: {allowed}.",
+        )
+    if not (1 <= top_k <= 50):
+        raise HTTPException(status_code=422, detail="top_k must be between 1 and 50.")
+
+    state = _get_state()
+    target_collection, text_field, dedup_key = _SIMILAR_COLLECTIONS[collection]
+
+    # Fetch the question's pre-computed vector and text.
+    source_point_id = stable_question_point_id(question_id)
+    point = state.qdrant.get_point(
+        QUESTIONS_COLLECTION, source_point_id, with_vectors=True
+    )
+    if point is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Question '{question_id}' not found in Qdrant. "
+            "Make sure it has been embedded with scripts/embed_questions.py.",
+        )
+
+    vector: list[float] = point["vector"]
+    texte_question: str = (point.get("payload") or {}).get("texte_question") or ""
+    if not texte_question:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Question '{question_id}' has no texte_question in its Qdrant payload.",
+        )
+
+    # When searching within the questions collection, exclude the source point
+    # so the question doesn't appear as its own nearest neighbour.
+    exclusion_filter: dict | None = None
+    if collection == "questions":
+        exclusion_filter = {"must_not": [{"has_id": [str(source_point_id)]}]}
+
+    # Retrieve a larger candidate pool before reranking.
+    candidates = retrieve_candidates(
+        precomputed_vectors=[vector],
+        qdrant=state.qdrant,
+        collection=target_collection,
+        top_k=max(top_k * 3, 20),
+        query_filter=exclusion_filter,
+        score_threshold=score_threshold,
+    )
+
+    # Rerank candidates against the question text.
+    scored = rerank_candidates(candidates, state.reranker, texte_question, text_field)
+
+    # For collections with multiple chunks per entity (offices), keep only the
+    # best-scoring chunk per entity so each office appears at most once.
+    if dedup_key is not None:
+        seen: dict[str, tuple[dict, float]] = {}
+        for candidate, score in scored:
+            key = (candidate.get("payload") or {}).get(dedup_key)
+            if key is None:
+                continue
+            if key not in seen or score > seen[key][1]:
+                seen[key] = (candidate, score)
+        scored = sorted(seen.values(), key=lambda x: -x[1])
+
+    hits = [
+        {
+            "id": candidate["id"],
+            "score": round(score, 6),
+            "payload": candidate.get("payload") or {},
+        }
+        for candidate, score in scored[:top_k]
+    ]
+
+    return {"question_id": question_id, "collection": collection, "hits": hits}

--- a/api/state.py
+++ b/api/state.py
@@ -20,6 +20,11 @@ class AppState:
 _state: AppState | None = None
 
 
+def set_state(state: AppState | None) -> None:
+    global _state
+    _state = state
+
+
 def _get_state() -> AppState:
     if _state is None:
         raise RuntimeError("Application has not started yet.")

--- a/api/state.py
+++ b/api/state.py
@@ -1,0 +1,26 @@
+"""Shared application state initialised at startup and accessed by route modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from qe.clients.qdrant import QdrantClient
+from qe.clients.rerank import RerankClient
+
+ALBERT_BASE_URL = "https://albert.api.etalab.gouv.fr"
+ALBERT_RERANK_MODEL = "openweight-rerank"
+
+
+@dataclass
+class AppState:
+    qdrant: QdrantClient
+    reranker: RerankClient
+
+
+_state: AppState | None = None
+
+
+def _get_state() -> AppState:
+    if _state is None:
+        raise RuntimeError("Application has not started yet.")
+    return _state

--- a/qe/answer_embedding.py
+++ b/qe/answer_embedding.py
@@ -124,15 +124,20 @@ def embed_answers(  # noqa: C901
 
     # Stale cleanup: scope to the same source filter so a scoped run never
     # touches points outside its remit.
-    all_db_ids = _load_all_answer_ids(source)
+    # When legislature is set, answers is a subset of all source answers, so we
+    # still need a separate query to avoid marking legislature-filtered answers
+    # as stale.
+    all_db_ids = (
+        {a.id for a in answers} if legislature is None else _load_all_answer_ids(source)
+    )
     stale_ids = [rid for rid in existing if rid not in all_db_ids]
     if stale_ids:
         logger.info("Removing %d stale point(s) (deleted from DB)...", len(stale_ids))
-        for rid in stale_ids:
-            qdrant.delete_points_by_filter(
-                collection,
-                {"must": [{"key": "reponse_id", "match": {"value": rid}}]},
-            )
+        stale_point_ids = [str(stable_answer_point_id(rid)) for rid in stale_ids]
+        qdrant.delete_points_by_filter(
+            collection,
+            {"must": [{"has_id": stale_point_ids}]},
+        )
         logger.info("  Done removing stale points.")
 
     to_embed: list[Reponse] = []

--- a/qe/assignment.py
+++ b/qe/assignment.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import logging
+
 from qe.clients.embedding import EmbeddingClient
 from qe.clients.qdrant import QdrantClient
 from qe.clients.rerank import RerankClient
+
+logger = logging.getLogger(__name__)
 
 
 def retrieve_candidates(
@@ -115,7 +119,12 @@ def rerank_candidates(
             if result.get("relevance_score") is not None
             else result.get("score")
         )
-        scored.append((candidates[idx], float(score or 0.0)))
+        if score is None:
+            logger.warning(
+                "Reranker returned no score for result at index %s; skipping.", idx
+            )
+            continue
+        scored.append((candidates[idx], float(score)))
 
     return sorted(scored, key=lambda x: -x[1])
 

--- a/qe/assignment.py
+++ b/qe/assignment.py
@@ -16,6 +16,7 @@ def retrieve_candidates(
     collection: str,
     top_k: int,
     query_filter: dict | None = None,
+    score_threshold: float | None = None,
 ) -> list[dict]:
     """Search Qdrant and return deduplicated candidates.
 
@@ -40,6 +41,8 @@ def retrieve_candidates(
         top_k: Number of nearest neighbours to retrieve per vector.
         query_filter: Optional Qdrant filter dict to restrict the search
             (e.g. filter by ``chunk_type``).
+        score_threshold: Optional minimum cosine similarity score (0.0–1.0).
+            Candidates below this threshold are dropped before reranking.
 
     Returns:
         Deduplicated list of Qdrant candidate dicts, each with ``"id"``,
@@ -63,12 +66,58 @@ def retrieve_candidates(
 
     seen_ids: dict[str, dict] = {}
     for vector in vectors:
-        candidates = qdrant.search(collection, vector, top_k, filter=query_filter)
+        candidates = qdrant.search(
+            collection,
+            vector,
+            top_k,
+            filter=query_filter,
+            score_threshold=score_threshold,
+        )
         for candidate in candidates:
             point_id = candidate.get("id")
             if point_id and str(point_id) not in seen_ids:
                 seen_ids[str(point_id)] = candidate
     return list(seen_ids.values())
+
+
+def rerank_candidates(
+    candidates: list[dict],
+    reranker: RerankClient,
+    query: str,
+    text_field: str,
+) -> list[tuple[dict, float]]:
+    """Rerank candidates by relevance and return (candidate, score) pairs.
+
+    Args:
+        candidates: Qdrant candidate dicts with ``"id"``, ``"score"``,
+            ``"payload"`` keys.
+        reranker: Albert rerank client.
+        query: The rerank query (full question text).
+        text_field: Payload key whose value is used as the document text.
+
+    Returns:
+        List of ``(candidate, rerank_score)`` tuples sorted by descending
+        score.  Empty if ``candidates`` is empty.
+    """
+    if not candidates:
+        return []
+
+    texts = [(c.get("payload") or {}).get(text_field) or "" for c in candidates]
+    results = reranker.rerank(query=query, documents=texts, top_n=len(texts))
+
+    scored: list[tuple[dict, float]] = []
+    for result in results:
+        idx = result.get("index")
+        if idx is None or idx >= len(candidates):
+            continue
+        score = (
+            result.get("relevance_score")
+            if result.get("relevance_score") is not None
+            else result.get("score")
+        )
+        scored.append((candidates[idx], float(score or 0.0)))
+
+    return sorted(scored, key=lambda x: -x[1])
 
 
 def build_matches(
@@ -93,35 +142,18 @@ def build_matches(
         contains ``rerank_position``, ``score``, and office payload fields.
         Returns an empty list if ``candidates`` is empty.
     """
-    if not candidates:
-        return []
-
-    candidate_texts: list[str] = [
-        (c.get("payload") or {}).get("text") or "" for c in candidates
-    ]
-    rerank_results = reranker.rerank(
-        query=query,
-        documents=candidate_texts,
-        top_n=len(candidate_texts),
-    )
+    scored = rerank_candidates(candidates, reranker, query, text_field="text")
 
     matches: list[dict] = []
-    for rerank_position, result in enumerate(rerank_results, start=1):
-        candidate_index = result.get("index")
-        if candidate_index is None or candidate_index >= len(candidates):
-            continue
-        candidate = candidates[candidate_index]
+    for rerank_position, (candidate, score) in enumerate(scored, start=1):
         payload = candidate.get("payload") or {}
-
         office_id = payload.get("office_id")
         if not office_id:
             continue
         matches.append(
             {
                 "rerank_position": rerank_position,
-                "score": result.get("relevance_score")
-                if result.get("relevance_score") is not None
-                else result.get("score"),
+                "score": score,
                 "office_id": office_id,
                 "office_name": payload.get("office_name"),
                 "direction": payload.get("direction"),

--- a/qe/clients/qdrant.py
+++ b/qe/clients/qdrant.py
@@ -90,6 +90,7 @@ class QdrantClient:
         top_k: int,
         *,
         filter: dict | None = None,
+        score_threshold: float | None = None,
     ) -> list[dict]:
         payload: dict = {
             "vector": vector,
@@ -99,6 +100,8 @@ class QdrantClient:
         }
         if filter is not None:
             payload["filter"] = filter
+        if score_threshold is not None:
+            payload["score_threshold"] = score_threshold
         response = requests.post(
             f"{self.base_url}/collections/{collection}/points/search",
             json=payload,


### PR DESCRIPTION
## Summary

- Add `GET /api/questions/{question_id}/similar` — reranked semantic search across `questions`, `answers`, and `offices` collections, starting from a stored question vector (no embedding API call needed). Parameters: `collection` (allowlisted), `top_k` (default 10, max 50), `score_threshold` (optional cosine pre-filter).
- Extract `rerank_candidates()` in `qe/assignment.py` as a generic helper (text field configurable); `build_matches()` now delegates to it — shared logic between both endpoints.
- Add `score_threshold` param to `QdrantClient.search()` and `retrieve_candidates()`, forwarded natively to Qdrant.
- Split `api/main.py` into three modules: `main.py` (thin shell), `state.py` (`AppState` + `_get_state()`), `questions.py` (`APIRouter` with all question routes).

## Test plan

- [ ] Start server: `ALBERT_API_KEY=... poetry run uvicorn api.main:app --reload`
- [ ] `GET /api/questions/{id}/similar?collection=questions` returns reranked similar questions (source excluded)
- [ ] `GET /api/questions/{id}/similar?collection=answers` returns reranked past answers
- [ ] `GET /api/questions/{id}/similar?collection=offices` returns one result per office (deduped chunks)
- [ ] `?collection=other` returns 422
- [ ] `?top_k=0` and `?top_k=51` return 422
- [ ] Unknown `question_id` returns 404
- [ ] Existing `GET /api/questions/{id}/attributions` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)