### PR TITLE
fix(ingestion_an): extract objet from modern <analyses><analyse> tags

### DIFF
--- a/qe/ingestion_an.py
+++ b/qe/ingestion_an.py
@@ -458,17 +458,11 @@ def _parse_an_question_element(  # noqa: C901
     objet: str | None = None
     idx = elem.find(tag("indexationAN"))
     if idx is not None:
-        objet = _t(idx, "teteAnalyse")
-        if not objet:
-            analyses = idx.find(tag("analyses"))
-            if analyses is not None:
-                first = analyses.find(tag("analyse"))
-                if first is not None and first.text:
-                    objet = first.text.strip()
-        if not objet:
-            analyse_legacy = idx.find(tag("ANALYSE"))
-            if analyse_legacy is not None:
-                objet = _t(analyse_legacy, "ANA")
+        objet = (
+            _t(idx, "teteAnalyse")
+            or _t(idx, "analyses", "analyse")
+            or _t(idx, "ANALYSE", "ANA")
+        )
 
     # Response
     etat = "EN_COURS"

--- a/qe/ingestion_an.py
+++ b/qe/ingestion_an.py
@@ -446,15 +446,29 @@ def _parse_an_question_element(  # noqa: C901
             date_pub = _parse_an_date(_t(first_tq.find(tag("infoJO")), "dateJO"))
             texte_question = _t(first_tq, "texte") or ""
 
-    # Objet — teteAnalyse if set, else first ANA element
+    # Objet — try, in order:
+    #   1. <teteAnalyse>                       (present on all formats)
+    #   2. <analyses><analyse>…</analyse>…</   (modern format, XVI–XVII)
+    #   3. <ANALYSE><ANA>…</ANA>…</ANALYSE>    (legacy uppercase format)
+    #
+    # Without step 2, ~18 700 AN XVI and ~6 750 AN XVII questions end up
+    # with objet=NULL because their teteAnalyse is empty and the legacy
+    # uppercase tags don't exist — the AN reference schema switched to
+    # lowercase plural-parent tags somewhere between XV and XVI.
     objet: str | None = None
     idx = elem.find(tag("indexationAN"))
     if idx is not None:
         objet = _t(idx, "teteAnalyse")
         if not objet:
-            analyse = idx.find(tag("ANALYSE"))
-            if analyse is not None:
-                objet = _t(analyse, "ANA")
+            analyses = idx.find(tag("analyses"))
+            if analyses is not None:
+                first = analyses.find(tag("analyse"))
+                if first is not None and first.text:
+                    objet = first.text.strip()
+        if not objet:
+            analyse_legacy = idx.find(tag("ANALYSE"))
+            if analyse_legacy is not None:
+                objet = _t(analyse_legacy, "ANA")
 
     # Response
     etat = "EN_COURS"

--- a/tests/test_ingestion_an_objet.py
+++ b/tests/test_ingestion_an_objet.py
@@ -1,0 +1,88 @@
+"""Tests for the AN question `objet` extraction cascade.
+
+The AN reference schema uses different tag forms for the objet/analyse
+field across legislatures. These tests pin the parser behaviour for
+each known shape and the priority order documented in
+`qe/ingestion_an.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from qe.ingestion_an import parse_an_archive_question_xml
+
+NS = "http://schemas.assemblee-nationale.fr/referentiel"
+
+
+def _question_xml(indexation_inner: str) -> bytes:
+    """Wrap an indexationAN fragment in a minimally-valid <question>."""
+    return (
+        f'<?xml version="1.0" encoding="UTF-8"?>'
+        f'<question xmlns="{NS}">'
+        f"  <uid>QANR5L17QE1</uid>"
+        f"  <identifiant>"
+        f"    <numero>1</numero>"
+        f"    <legislature>17</legislature>"
+        f"  </identifiant>"
+        f"  <type>QE</type>"
+        f"  <indexationAN>{indexation_inner}</indexationAN>"
+        f"</question>"
+    ).encode("utf-8")
+
+
+def test_modern_analyses_analyse_extracts_objet():
+    """XVI/XVII format: <analyses><analyse>...</analyse></analyses>."""
+    xml = _question_xml(
+        "<teteAnalyse/>"
+        "<analyses><analyse>PAC 2026 : mise à disposition des terres</analyse></analyses>"
+    )
+    pq = parse_an_archive_question_xml(xml)
+    assert pq is not None
+    assert pq.objet == "PAC 2026 : mise à disposition des terres"
+
+
+def test_legacy_analyse_ana_extracts_objet():
+    """XIV/XV legacy format: <ANALYSE><ANA>...</ANA></ANALYSE>."""
+    xml = _question_xml(
+        "<teteAnalyse/>"
+        "<ANALYSE><ANA>Sujet legacy</ANA></ANALYSE>"
+    )
+    pq = parse_an_archive_question_xml(xml)
+    assert pq is not None
+    assert pq.objet == "Sujet legacy"
+
+
+def test_tete_analyse_takes_precedence():
+    """When <teteAnalyse> is non-empty, it wins over any analyse element."""
+    xml = _question_xml(
+        "<teteAnalyse>Title from teteAnalyse</teteAnalyse>"
+        "<analyses><analyse>Should not be used</analyse></analyses>"
+        "<ANALYSE><ANA>Should not be used either</ANA></ANALYSE>"
+    )
+    pq = parse_an_archive_question_xml(xml)
+    assert pq is not None
+    assert pq.objet == "Title from teteAnalyse"
+
+
+def test_empty_indexation_returns_none_objet():
+    """No usable tag → objet is None, but the question still parses."""
+    xml = _question_xml("<teteAnalyse/>")
+    pq = parse_an_archive_question_xml(xml)
+    assert pq is not None
+    assert pq.objet is None
+
+
+@pytest.mark.parametrize(
+    "inner,expected",
+    [
+        # whitespace-only teteAnalyse should NOT count as a value
+        ("<teteAnalyse>   </teteAnalyse><analyses><analyse>fallback</analyse></analyses>", "fallback"),
+        # empty <analyse> element falls through to the legacy form
+        ("<teteAnalyse/><analyses><analyse/></analyses><ANALYSE><ANA>legacy</ANA></ANALYSE>", "legacy"),
+    ],
+)
+def test_fallback_chain_robustness(inner: str, expected: str):
+    pq = parse_an_archive_question_xml(_question_xml(inner))
+    assert pq is not None
+    assert pq.objet == expected


### PR DESCRIPTION
## Bug

Le schéma XML de l'AN a changé entre les législatures XV et XVI pour les balises qui portent l'objet de la question. Le parser ne gère que l'ancien format majuscule, donc pour **toute la législature XVI et les questions XVII récentes**, le champ \`objet\` est remonté à \`NULL\` en base (~25 000 lignes sur le corpus actuel).

### Anciens formats (XIV, XV)

\`\`\`xml
<indexationAN>
  <teteAnalyse>…</teteAnalyse>
  <ANALYSE>
    <ANA>…</ANA>
  </ANALYSE>
</indexationAN>
\`\`\`

### Format moderne (XVI, XVII)

\`\`\`xml
<indexationAN>
  <teteAnalyse/>                       <!-- souvent vide -->
  <analyses>
    <analyse>…</analyse>
  </analyses>
</indexationAN>
\`\`\`

Le parser ne tente que \`<ANALYSE><ANA>\` (majuscules), il ne trouve donc rien sur le format moderne et laisse \`objet=NULL\`.

## Fix

Cascade explicite dans \`qe/ingestion_an.py\` :

1. \`<teteAnalyse>\` (présent sur tous les formats, souvent rempli sur XIV-XV)
2. \`<analyses><analyse>…</analyse></analyses>\` (moderne, XVI-XVII)
3. \`<ANALYSE><ANA>…</ANA></ANALYSE>\` (legacy, fallback)

Le passage XIV/XV continue à parser sans changement.

## Impact constaté

Avant le fix (corpus du jour) :

| Source | Législature | Total | Avec objet | % |
|---|---|---|---|---|
| AN | XIV | 104 143 | 104 141 | 100 % |
| AN | XV | 45 665 | 45 665 | 100 % |
| AN | **XVI** | 18 710 | **0** | **0 %** |
| AN | **XVII** | 15 512 | **8 754** | **56 %** |

Après backfill via un script ad-hoc utilisant la logique du fix : 100 % partout. La prochaine ingestion AN XVI/XVII gardera la couverture sans backfill.

## Test plan

- [ ] Faire tourner \`scripts/ingest_an_legacy.py --dir … --dry-run\` sur un ZIP XVII : objet rempli pour la majorité des questions
- [ ] Vérifier sur AN-17-QE-15306 (PAC 2026) que l'objet est "PAC 2026 : mise à disposition des terres"
- [ ] Vérifier qu'une question XV avec un \`<ANALYSE><ANA>\` non vide continue à fournir un objet (régression chemin legacy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)