### PR TITLE
fix(ingest): rubrique as last-resort objet fallback (complément de #39)

### DIFF
--- a/qe/ingestion_an.py
+++ b/qe/ingestion_an.py
@@ -451,6 +451,9 @@ def _parse_an_question_element(  # noqa: C901
     #   1. <teteAnalyse>                       (present on all formats)
     #   2. <analyses><analyse>…</analyse>…</   (modern format, XVI–XVII)
     #   3. <ANALYSE><ANA>…</ANA>…</ANALYSE>    (legacy uppercase format)
+    #   4. <rubrique>                          (broad topic — last-resort
+    #                                           fallback so the question
+    #                                           never ends up with a blank title)
     #
     # Without step 2, ~18 700 AN XVI and ~6 750 AN XVII questions end up
     # with objet=NULL because their teteAnalyse is empty and the legacy
@@ -463,6 +466,7 @@ def _parse_an_question_element(  # noqa: C901
             _t(idx, "teteAnalyse")
             or _t(idx, "analyses", "analyse")
             or _t(idx, "ANALYSE", "ANA")
+            or _t(idx, "rubrique")
         )
 
     # Response

--- a/tests/test_ingestion_an_objet.py
+++ b/tests/test_ingestion_an_objet.py
@@ -73,6 +73,31 @@ def test_empty_indexation_returns_none_objet():
     assert pq.objet is None
 
 
+def test_rubrique_used_as_last_resort():
+    """Freshly-published questions may carry a <rubrique> before any
+    <analyse> has been written; the rubrique then serves as the title."""
+    xml = _question_xml(
+        "<rubrique>retraites : fonctionnaires civils et militaires</rubrique>"
+        "<teteAnalyse/>"
+        "<analyses><analyse/></analyses>"
+    )
+    pq = parse_an_archive_question_xml(xml)
+    assert pq is not None
+    assert pq.objet == "retraites : fonctionnaires civils et militaires"
+
+
+def test_rubrique_not_used_when_analyse_present():
+    """The broad rubrique must never shadow a specific analyse."""
+    xml = _question_xml(
+        "<rubrique>énergie et carburants</rubrique>"
+        "<teteAnalyse/>"
+        "<analyses><analyse>Prix de l'électricité en zone rurale</analyse></analyses>"
+    )
+    pq = parse_an_archive_question_xml(xml)
+    assert pq is not None
+    assert pq.objet == "Prix de l'électricité en zone rurale"
+
+
 @pytest.mark.parametrize(
     "inner,expected",
     [


### PR DESCRIPTION
## Périmètre (mis à jour — 2026-08-07)

> **Note** : la version initiale de cette PR portait le fix complet du schéma XVII (`<analyses><analyse>`). Ce travail a été réalisé indépendamment par #39 (mergée le 03/06). Après rebase, cette PR ne porte plus que le **complément** : le fallback `<rubrique>`.

## Ce que fait cette PR

Ajoute un 4ᵉ étage à la cascade d'extraction de l'objet :

1. `<teteAnalyse>` — titre synthétisé (rare)
2. `<analyses><analyse>` — format moderne XVI/XVII *(déjà dans main via #39)*
3. `<ANALYSE><ANA>` — format legacy XIV/XV *(déjà dans main)*
4. **`<rubrique>` — nouveau** : thème large, dernier recours

## Pourquoi

**Robustesse pour les questions fraîchement publiées.** L'archive XVII est vivante ; une question peut être publiée avec sa `<rubrique>` renseignée avant que l'`<analyse>` ne soit rédigée par les services de l'AN. Sans ce fallback, elle s'affiche « (Sans objet) » dans QE Explorer jusqu'au prochain re-ingest. Avec, elle affiche au moins son thème.

Le sens de mise à jour est le bon : quand l'`analyse` arrive au re-ingest suivant, l'upsert `COALESCE(excluded.objet, questions.objet)` remplace la rubrique générique par l'analyse spécifique (l'entrant non-NULL gagne).

**Bénéfice mesuré sur le corpus actuel : marginal.** Après les re-ingests avec le parser de #39, il ne reste que 2 lignes AN à objet NULL (`AN-14-QE-60801`, `AN-14-QE-61032`), non re-parsées depuis (archive XIV non retéléchargée). La valeur de cette PR est préventive, pas curative.

## Risque connu (soulevé par revu-bot)

Avec ce fallback, `excluded.objet` n'est presque plus jamais NULL → un re-ingest où l'AN aurait *retiré* une `analyse` d'un XML publié remplacerait un objet spécifique stocké par la rubrique générique. Assumé : (a) le scénario demande une régression de l'indexation côté AN, jamais observée ; (b) l'archive AN est la source de vérité — si elle ne contient plus l'analyse, refléter son état est défendable ; (c) l'alternative (préserver l'existant) bloquerait aussi les mises à jour légitimes.

## Tests

`tests/test_ingestion_an_objet.py` (suite de #39) étendu de 2 cas :
- `test_rubrique_used_as_last_resort` — rubrique utilisée quand toutes les sources d'analyse sont vides
- `test_rubrique_not_used_when_analyse_present` — la rubrique ne masque jamais une analyse spécifique

Suite complète : 26/26 ✓, ruff ✓.

## Coordination

Aucun conflit avec les PRs ouvertes : #43 modifie `ingestion_an.py` mais uniquement le bloc `reponse_id` (hunks disjoints) ; #41/#44/#45 ne touchent pas ce fichier. Mergeable à tout moment (cf. commentaire du 17/07).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
