### PR TITLE
feat(direction): add direction_algo_id cache column on questions (PR-A)

### DIFF
--- a/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
+++ b/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
@@ -37,12 +37,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # Nullable — most questions will be NULL until the backfill runs.
+    # FK constraint is explicitly named so re-runs don't create silent
+    # duplicates and downgrade() knows what to drop.
     op.add_column(
         "questions",
         sa.Column(
             "direction_algo_id",
             sa.Integer(),
-            sa.ForeignKey("directions.id", ondelete="SET NULL"),
+            sa.ForeignKey(
+                "directions.id",
+                name="fk_questions_direction_algo_id",
+                ondelete="SET NULL",
+            ),
             nullable=True,
         ),
     )
@@ -54,14 +60,15 @@ def upgrade() -> None:
             nullable=True,
         ),
     )
-    # Index for the filter predicate used by the "similar questions" query.
-    # Small direction table (~15 rows) → partial index is unnecessary; a
-    # plain btree on the FK is enough and helps both single-direction
-    # lookups and multi-direction IN () filters.
+    # Partial index — skip the ~260k NULL rows we'll have between the
+    # migration and the first backfill run. The filter predicate we
+    # care about is always `direction_algo_id = X` (or IN (…)), so NULL
+    # rows in the index are pure overhead.
     op.create_index(
         "ix_questions_direction_algo_id",
         "questions",
         ["direction_algo_id"],
+        postgresql_where=sa.text("direction_algo_id IS NOT NULL"),
     )
 
 

--- a/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
+++ b/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
@@ -19,7 +19,7 @@ request would be prohibitively slow — hence a cache. This migration
 only adds the columns; scripts and wiring live in the qe-front repo.
 
 Revision ID: d5a1c2f3e4b6
-Revises: a9b0c1d2e3f4
+Revises: e5f6c7d8a9b1
 Create Date: 2026-07-18
 """
 
@@ -30,7 +30,7 @@ from alembic import op
 
 
 revision: str = "d5a1c2f3e4b6"
-down_revision: Union[str, Sequence[str], None] = "62ff467c436e"
+down_revision: Union[str, Sequence[str], None] = "e5f6c7d8a9b1"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
+++ b/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
@@ -30,7 +30,7 @@ from alembic import op
 
 
 revision: str = "d5a1c2f3e4b6"
-down_revision: Union[str, Sequence[str], None] = "a9b0c1d2e3f4"
+down_revision: Union[str, Sequence[str], None] = "62ff467c436e"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
+++ b/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
@@ -1,0 +1,71 @@
+"""add direction_algo_id cache to questions
+
+Persists the last direction top-1 returned by the kNN attribution algo
+for each question. Priority read order is:
+
+    COALESCE(question_attributions.direction_reelle_id,
+             questions.direction_algo_id)
+
+The cache is (re)written by:
+  * a one-shot backfill script over the whole corpus (~260k QE)
+  * the attribution-direction API route each time it runs (write-behind)
+  * a small backfill script for new questions (cron / post-ingest hook)
+
+Rationale: the "similar questions" pipeline benefits massively from a
+direction filter on candidates (+22 pts on hit@3 in leave-one-out eval,
+see docs/rapport_performance_v2.md, Expé 9). That filter needs a
+direction per question, and running the kNN algo synchronously per
+request would be prohibitively slow — hence a cache. This migration
+only adds the columns; scripts and wiring live in the qe-front repo.
+
+Revision ID: d5a1c2f3e4b6
+Revises: a9b0c1d2e3f4
+Create Date: 2026-07-18
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "d5a1c2f3e4b6"
+down_revision: Union[str, Sequence[str], None] = "a9b0c1d2e3f4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Nullable — most questions will be NULL until the backfill runs.
+    op.add_column(
+        "questions",
+        sa.Column(
+            "direction_algo_id",
+            sa.Integer(),
+            sa.ForeignKey("directions.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "questions",
+        sa.Column(
+            "direction_algo_computed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    # Index for the filter predicate used by the "similar questions" query.
+    # Small direction table (~15 rows) → partial index is unnecessary; a
+    # plain btree on the FK is enough and helps both single-direction
+    # lookups and multi-direction IN () filters.
+    op.create_index(
+        "ix_questions_direction_algo_id",
+        "questions",
+        ["direction_algo_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_questions_direction_algo_id", table_name="questions")
+    op.drop_column("questions", "direction_algo_computed_at")
+    op.drop_column("questions", "direction_algo_id")

--- a/qe/models.py
+++ b/qe/models.py
@@ -188,6 +188,20 @@ class Question(Base):
     )
     date_retrait: Mapped[date | None] = mapped_column(Date, nullable=True)
 
+    # --- direction cache algo (last top-1 from kNN attribution) ---
+    # Filled by a backfill batch + write-behind from the attribution
+    # module. Read priority is `question_attributions.direction_reelle_id`
+    # first, this only as fallback. See docs/rapport_performance_v2.md.
+    direction_algo_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("directions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    direction_algo_computed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # --- méta ingestion ---
     ingest_source: Mapped[str] = mapped_column(
         Text, nullable=False

--- a/qe/models.py
+++ b/qe/models.py
@@ -192,9 +192,18 @@ class Question(Base):
     # Filled by a backfill batch + write-behind from the attribution
     # module. Read priority is `question_attributions.direction_reelle_id`
     # first, this only as fallback. See docs/rapport_performance_v2.md.
+    #
+    # No `relationship()` here because the `directions` table lives in
+    # the qe-front repo (its schema and CRUD are owned there). The FK
+    # constraint holds at the DB level; Python code that needs the
+    # direction row queries it explicitly rather than lazy-loading it.
     direction_algo_id: Mapped[int | None] = mapped_column(
         Integer,
-        ForeignKey("directions.id", ondelete="SET NULL"),
+        ForeignKey(
+            "directions.id",
+            name="fk_questions_direction_algo_id",
+            ondelete="SET NULL",
+        ),
         nullable=True,
         index=True,
     )


### PR DESCRIPTION
## Résumé

**PR-A du chantier « filtre par direction »** — voir plan complet dans le repo qe-front → `docs/direction-filter-plan.md`.

Cette PR ne fait qu'ajouter le schéma. Elle est **indépendante et mergeable dès validation**. Le backfill et le wiring vivent dans le repo `qe-front` (PRs B, C, D, E).

## Contexte

La session d'exploration du 2026-07-18 (voir `docs/rapport_performance_v2.md` — Expé 9) a montré que **filtrer les candidates de l'algo « questions similaires » par la direction attributaire de la QE source apporte +22 points sur hit@3** (57 % → 79 %) sur la vérité terrain DGCS main-tagué. C'est le seul levier identifié qui améliore concrètement l'algo actuel sans le remplacer.

Pour appliquer ce filtre efficacement, on a besoin d'une direction par question. On ne peut pas la calculer synchrone à chaque requête (algo kNN = quelques dizaines de ms × 500 candidates × N requêtes concurrentes). D'où ce cache.

## Ce que fait cette PR

Ajoute 2 colonnes à `questions` :
- `direction_algo_id` — FK vers `directions`, nullable, ON DELETE SET NULL. Stocke le dernier top-1 renvoyé par l'algo kNN d'attribution.
- `direction_algo_computed_at` — timestamp pour tracer la fraîcheur.

Plus un index btree `ix_questions_direction_algo_id` pour les filtres.

## Politique de lecture (implémentée dans les PRs suivantes)

```
direction effective d'une QE =
  COALESCE(question_attributions.direction_reelle_id,   -- humain (~11k QE)
           questions.direction_algo_id)                  -- algo cache (~248k QE)
```

Attribution humaine gagne toujours. L'algo n'est utilisé qu'en fallback.

## Politique d'écriture (implémentée dans les PRs suivantes)

| Événement | Écrit dans |
|---|---|
| Backfill batch initial | `direction_algo_id` |
| Cron pour nouvelles QE | `direction_algo_id` |
| Appel `/api/questions/[id]/direction-attributions` | `direction_algo_id` (write-behind) |
| Agent valide/modifie via UI attribution | `direction_reelle_id` |
| Import périodique tableau DGCS/DGOS/DSS | `direction_reelle_id` |

## Test plan
- [ ] `alembic upgrade head` applique la migration sans erreur
- [ ] Rollback `alembic downgrade -1` fonctionne
- [ ] Le modèle SQLAlchemy `Question` accepte les 2 nouveaux champs
- [ ] Aucune régression sur les autres endpoints (pur ajout de colonnes)