### PR TITLE
fix(embed): résilience aux blocages guardrail (403 content-block)

### DIFF
--- a/qe/answer_embedding.py
+++ b/qe/answer_embedding.py
@@ -179,8 +179,14 @@ def embed_answers(  # noqa: C901
         "Probing embedding dimension with first batch (%d answer(s))...",
         len(first_batch_texts),
     )
-    first_embeddings = embedder.embed_batch(first_batch_texts)
-    vector_size = len(first_embeddings[0])
+    first_embeddings = embedder.embed_batch_partial(first_batch_texts)
+    probe = next((e for e in first_embeddings if e is not None), None)
+    if probe is None:
+        raise ValueError(
+            "Every text in the probe batch was rejected by the content "
+            "guardrail — cannot determine the embedding dimension."
+        )
+    vector_size = len(probe)
 
     existing_dim = vector_store.get_vector_size(collection)
     if existing_dim is None:
@@ -194,6 +200,7 @@ def embed_answers(  # noqa: C901
         )
 
     upserted = 0
+    blocked = 0
     batches = list(batched(to_embed, batch_size))
 
     with tqdm(total=len(to_embed), unit="a", desc="Embedding answers") as progress:
@@ -203,12 +210,21 @@ def embed_answers(  # noqa: C901
             else:
                 if rate_limiter:
                     rate_limiter.acquire(1)
-                embeddings = embedder.embed_batch(
+                embeddings = embedder.embed_batch_partial(
                     [a.texte_reponse[:TEXT_MAX_CHARS] for a in batch]
                 )
 
             points = []
             for answer, embedding in zip(batch, embeddings, strict=True):
+                if embedding is None:
+                    # Rejected by the content guardrail — skip this answer
+                    # but keep embedding the rest of the corpus.
+                    blocked += 1
+                    logger.warning(
+                        "Answer %s skipped (blocked by content guardrail).",
+                        answer.id,
+                    )
+                    continue
                 date_str = (
                     answer.date_reponse_jo.isoformat()
                     if answer.date_reponse_jo
@@ -235,14 +251,17 @@ def embed_answers(  # noqa: C901
                     }
                 )
 
-            vector_store.upsert_points(collection, points)
-            upserted += len(batch)
+            if points:
+                vector_store.upsert_points(collection, points)
+            upserted += len(points)
             progress.update(len(batch))
 
     logger.info(
-        "Done — %d upserted, %d skipped (up-to-date), %d stale removed.",
+        "Done — %d upserted, %d skipped (up-to-date), %d blocked by "
+        "guardrail, %d stale removed.",
         upserted,
         skipped,
+        blocked,
         len(stale_ids),
     )
     return EmbedStats(

--- a/qe/clients/embedding.py
+++ b/qe/clients/embedding.py
@@ -9,16 +9,19 @@ import requests
 logger = logging.getLogger(__name__)
 
 # Markers that identify a guardrail rejection (e.g. the platform's
-# EU-AI-Act content filters) in a 403 response body. Distinct from an
-# auth 403, whose body carries none of these — auth failures must keep
-# raising immediately instead of triggering a pointless per-item retry.
-_CONTENT_BLOCK_MARKERS = ("Content blocked", "guardrail")
+# EU-AI-Act content filters) in a 403 response body. Matched
+# case-insensitively, and deliberately specific ("content blocked" is
+# the platform's error message prefix, "guardrail_name" its JSON field)
+# — a generic word like "guardrail" alone could match an unrelated 403
+# body and silently convert an outage into mass per-item skips. Auth
+# 403s carry none of these and must keep raising immediately.
+_CONTENT_BLOCK_MARKERS = ("content blocked", "guardrail_name")
 
 
 def _is_content_block(response: requests.Response) -> bool:
     if response.status_code != 403:
         return False
-    body = response.text[:2000]
+    body = response.text[:2000].lower()
     return any(marker in body for marker in _CONTENT_BLOCK_MARKERS)
 
 

--- a/qe/clients/embedding.py
+++ b/qe/clients/embedding.py
@@ -8,6 +8,23 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# Markers that identify a guardrail rejection (e.g. the platform's
+# EU-AI-Act content filters) in a 403 response body. Distinct from an
+# auth 403, whose body carries none of these — auth failures must keep
+# raising immediately instead of triggering a pointless per-item retry.
+_CONTENT_BLOCK_MARKERS = ("Content blocked", "guardrail")
+
+
+def _is_content_block(response: requests.Response) -> bool:
+    if response.status_code != 403:
+        return False
+    body = response.text[:2000]
+    return any(marker in body for marker in _CONTENT_BLOCK_MARKERS)
+
+
+class ContentBlockedError(Exception):
+    """A text was rejected by the platform's content guardrails."""
+
 
 class EmbeddingClient:
     """Generate text embeddings via the Albert API."""
@@ -20,11 +37,9 @@ class EmbeddingClient:
         self.api_key = api_key
         self.timeout = timeout
 
-    def embed(self, text: str) -> list[float]:
-        return self.embed_batch([text])[0]
-
-    def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        response = requests.post(
+    def _post(self, texts: list[str]) -> requests.Response:
+        """Single API round-trip. Seam for tests (subclass and override)."""
+        return requests.post(
             self.url,
             headers={
                 "Authorization": f"Bearer {self.api_key}",
@@ -36,6 +51,12 @@ class EmbeddingClient:
             },
             timeout=self.timeout,
         )
+
+    def embed(self, text: str) -> list[float]:
+        return self.embed_batch([text])[0]
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        response = self._post(texts)
         if not response.ok:
             logger.error(
                 "Embedding API error %d for %d text(s): %s",
@@ -43,8 +64,46 @@ class EmbeddingClient:
                 len(texts),
                 response.text[:500],
             )
+            if _is_content_block(response):
+                raise ContentBlockedError(response.text[:500])
             response.raise_for_status()
         data = response.json()
         return [
             item["embedding"] for item in sorted(data["data"], key=lambda x: x["index"])
         ]
+
+    def embed_batch_partial(self, texts: list[str]) -> list[list[float] | None]:
+        """Like embed_batch, but survives guardrail rejections.
+
+        When the whole batch is accepted, behaves exactly like
+        embed_batch. When the batch is rejected by a content guardrail
+        (403 with a content-block body), falls back to embedding each
+        text individually; blocked texts yield None at their position so
+        the result stays aligned 1:1 with the input.
+
+        Auth failures and other HTTP errors raise as usual — a broken
+        key must not degrade into one failing API call per text.
+        """
+        try:
+            return list(self.embed_batch(texts))
+        except ContentBlockedError:
+            logger.warning(
+                "Batch of %d text(s) rejected by content guardrail — "
+                "retrying one by one to isolate the blocked text(s).",
+                len(texts),
+            )
+
+        results: list[list[float] | None] = []
+        blocked = 0
+        for text in texts:
+            try:
+                results.append(self.embed_batch([text])[0])
+            except ContentBlockedError:
+                results.append(None)
+                blocked += 1
+        logger.warning(
+            "Guardrail fallback done: %d/%d text(s) blocked and skipped.",
+            blocked,
+            len(texts),
+        )
+        return results

--- a/scripts/embed_questions.py
+++ b/scripts/embed_questions.py
@@ -366,8 +366,14 @@ def embed_questions(  # noqa: C901
         "Probing embedding dimension with first batch (%d question(s))...",
         len(first_batch_texts),
     )
-    first_embeddings = embedder.embed_batch(first_batch_texts)
-    vector_size = len(first_embeddings[0])
+    first_embeddings = embedder.embed_batch_partial(first_batch_texts)
+    probe = next((e for e in first_embeddings if e is not None), None)
+    if probe is None:
+        raise ValueError(
+            "Every text in the probe batch was rejected by the content "
+            "guardrail — cannot determine the embedding dimension."
+        )
+    vector_size = len(probe)
 
     if not vector_store.collection_exists(collection):
         vector_store.create_collection(collection, vector_size=vector_size)
@@ -375,6 +381,7 @@ def embed_questions(  # noqa: C901
 
     # --- Batch embed + upsert with progress bar ---
     upserted = 0
+    blocked = 0
     batches = list(_batched(to_embed, batch_size))
 
     with tqdm(total=len(to_embed), unit="q", desc="Embedding") as progress:
@@ -387,10 +394,19 @@ def embed_questions(  # noqa: C901
             else:
                 if rate_limiter:
                     rate_limiter.acquire(1)
-                embeddings = embedder.embed_batch(texts)
+                embeddings = embedder.embed_batch_partial(texts)
 
             points = []
             for question, embedding in zip(batch, embeddings, strict=True):
+                if embedding is None:
+                    # Rejected by the content guardrail — skip this question
+                    # but keep embedding the rest of the corpus.
+                    blocked += 1
+                    logger.warning(
+                        "Question %s skipped (blocked by content guardrail).",
+                        question.id,
+                    )
+                    continue
                 date_str = (
                     question.date_publication_jo.isoformat()
                     if question.date_publication_jo
@@ -419,13 +435,16 @@ def embed_questions(  # noqa: C901
                     }
                 )
 
-            vector_store.upsert_points(collection, points)
-            upserted += len(batch)
+            if points:
+                vector_store.upsert_points(collection, points)
+            upserted += len(points)
             progress.update(len(batch))
 
     logger.info(
-        "Done — %d upserted, %d skipped (up-to-date), %d stale removed.",
+        "Done — %d upserted, %d blocked by guardrail, "
+        "%d skipped (up-to-date), %d stale removed.",
         upserted,
+        blocked,
         skipped,
         len(stale_ids),
     )

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -1,0 +1,101 @@
+"""Tests for the embedding client's guardrail-resilience fallback.
+
+The platform's content guardrails (e.g. EU-AI-Act filters) can reject a
+batch with HTTP 403 + a "Content blocked" body. `embed_batch_partial`
+must isolate the blocked text(s) by retrying one by one, while plain
+auth failures must keep raising immediately (no 272k-item retry storm
+on a revoked key).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests
+
+from qe.clients.embedding import ContentBlockedError, EmbeddingClient
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict | None = None, text: str = ""):
+        self.status_code = status_code
+        self.ok = status_code < 400
+        self._payload = payload or {}
+        self.text = text or json.dumps(self._payload)
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise requests.HTTPError(f"{self.status_code}", response=self)
+
+
+def _ok_response(n_texts: int) -> _FakeResponse:
+    return _FakeResponse(
+        200,
+        {"data": [{"index": i, "embedding": [float(i)]} for i in range(n_texts)]},
+    )
+
+
+_BLOCKED = _FakeResponse(
+    403,
+    text='{"error":{"message":"Content blocked: eu_ai_act_art5 match","code":"403"}}',
+)
+_AUTH_DENIED = _FakeResponse(403, text='{"detail":"Forbidden"}')
+
+
+class _ScriptedClient(EmbeddingClient):
+    """Overrides the transport seam with a scripted response per call."""
+
+    def __init__(self, script):
+        super().__init__(url="http://test", model="m", api_key="k")
+        self._script = list(script)
+        self.calls: list[list[str]] = []
+
+    def _post(self, texts):
+        self.calls.append(list(texts))
+        action = self._script.pop(0)
+        return action(texts) if callable(action) else action
+
+
+def test_partial_happy_path_is_a_single_batch_call():
+    client = _ScriptedClient([lambda texts: _ok_response(len(texts))])
+    result = client.embed_batch_partial(["a", "b", "c"])
+    assert result == [[0.0], [1.0], [2.0]]
+    assert len(client.calls) == 1
+
+
+def test_partial_isolates_the_blocked_text():
+    client = _ScriptedClient(
+        [
+            _BLOCKED,  # whole batch rejected
+            lambda texts: _ok_response(1),  # "a" alone → OK
+            _BLOCKED,  # "b" alone → blocked
+            lambda texts: _ok_response(1),  # "c" alone → OK
+        ]
+    )
+    result = client.embed_batch_partial(["a", "b", "c"])
+    assert result == [[0.0], None, [0.0]]
+    assert client.calls == [["a", "b", "c"], ["a"], ["b"], ["c"]]
+
+
+def test_auth_403_raises_without_per_item_fallback():
+    client = _ScriptedClient([_AUTH_DENIED])
+    with pytest.raises(requests.HTTPError):
+        client.embed_batch_partial(["a", "b"])
+    assert len(client.calls) == 1  # no retry storm on a revoked key
+
+
+def test_server_error_raises_without_fallback():
+    client = _ScriptedClient([_FakeResponse(500, text="oops")])
+    with pytest.raises(requests.HTTPError):
+        client.embed_batch_partial(["a"])
+    assert len(client.calls) == 1
+
+
+def test_embed_batch_raises_typed_error_on_content_block():
+    client = _ScriptedClient([_BLOCKED])
+    with pytest.raises(ContentBlockedError):
+        client.embed_batch(["a"])

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -39,11 +39,16 @@ def _ok_response(n_texts: int) -> _FakeResponse:
     )
 
 
-_BLOCKED = _FakeResponse(
-    403,
-    text='{"error":{"message":"Content blocked: eu_ai_act_art5 match","code":"403"}}',
-)
-_AUTH_DENIED = _FakeResponse(403, text='{"detail":"Forbidden"}')
+def _blocked() -> _FakeResponse:
+    """Fresh instance per use — no state shared between tests."""
+    return _FakeResponse(
+        403,
+        text='{"error":{"message":"Content blocked: eu_ai_act_art5 match","code":"403"}}',
+    )
+
+
+def _auth_denied() -> _FakeResponse:
+    return _FakeResponse(403, text='{"detail":"Forbidden"}')
 
 
 class _ScriptedClient(EmbeddingClient):
@@ -70,9 +75,9 @@ def test_partial_happy_path_is_a_single_batch_call():
 def test_partial_isolates_the_blocked_text():
     client = _ScriptedClient(
         [
-            _BLOCKED,  # whole batch rejected
+            _blocked(),  # whole batch rejected
             lambda texts: _ok_response(1),  # "a" alone → OK
-            _BLOCKED,  # "b" alone → blocked
+            _blocked(),  # "b" alone → blocked
             lambda texts: _ok_response(1),  # "c" alone → OK
         ]
     )
@@ -82,7 +87,7 @@ def test_partial_isolates_the_blocked_text():
 
 
 def test_auth_403_raises_without_per_item_fallback():
-    client = _ScriptedClient([_AUTH_DENIED])
+    client = _ScriptedClient([_auth_denied()])
     with pytest.raises(requests.HTTPError):
         client.embed_batch_partial(["a", "b"])
     assert len(client.calls) == 1  # no retry storm on a revoked key
@@ -96,6 +101,6 @@ def test_server_error_raises_without_fallback():
 
 
 def test_embed_batch_raises_typed_error_on_content_block():
-    client = _ScriptedClient([_BLOCKED])
+    client = _ScriptedClient([_blocked()])
     with pytest.raises(ContentBlockedError):
         client.embed_batch(["a"])


### PR DESCRIPTION
## Problème

Les guardrails de contenu de la plateforme (filtres EU-AI-Act) rejettent certains batches avec un `403` + body « Content blocked » — observé en réel le 07/08 : le backlog d'embedding des réponses AN (209 149 items) est mort à l'item 832 sur un match `eu_ai_act_art5_social_scoring_fr` (« identifier + fiabilité ») dans un texte de réponse. Le batch Sénat (62 942) est mort dès le batch de probe.

Les deux consommateurs (`qe/answer_embedding.py`, `scripts/embed_questions.py`) traitaient tout échec de batch comme fatal → un seul texte bloqué avortait la totalité du run.

## Fix

**`EmbeddingClient`** :
- Distingue le 403-guardrail (body contenant « Content blocked »/« guardrail ») du 403-auth via `ContentBlockedError`
- Nouvelle méthode `embed_batch_partial` : batch entier d'abord ; si rejet guardrail, retry texte par texte, `None` aux positions bloquées (liste alignée 1:1 avec l'entrée)
- Les échecs d'auth et les 5xx lèvent immédiatement comme avant — une clé révoquée ne doit pas dégénérer en 272k appels unitaires
- Extraction d'un seam `_post()` pour les tests (convention du projet : subclass plutôt que mock.patch)

**Consommateurs** : skip des items `None` (comptés, loggés item par item + résumé final), l'upsert continue. Le probe de dimension prend le premier embedding non-None du premier batch.

## Limite connue

Le fallback unitaire fait jusqu'à `batch_size` appels supplémentaires non comptés par le rate-limiter du caller (acquis par batch). Acceptable vu la rareté des blocages ; à revisiter si les guardrails se resserrent.

## Tests

`tests/test_embedding_client.py` — 5 cas : happy path en un seul appel, isolation du texte bloqué (positions préservées), 403-auth sans fallback (1 seul appel), 500 sans fallback, erreur typée. Suite complète : 29/29 ✓, ruff ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)