### PR TITLE
fix(db): rattrapage du nom de la table d'attributions pour les bases antérieures au squash

### DIFF
--- a/alembic/versions/e7f8a9b0c1d2_rename_question_attributions.py
+++ b/alembic/versions/e7f8a9b0c1d2_rename_question_attributions.py
@@ -32,7 +32,7 @@ from typing import Union
 from alembic import op
 
 revision: str = "e7f8a9b0c1d2"
-down_revision: Union[str, Sequence[str], None] = "62ff467c436e"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/e7f8a9b0c1d2_rename_question_attributions.py
+++ b/alembic/versions/e7f8a9b0c1d2_rename_question_attributions.py
@@ -1,0 +1,72 @@
+"""Catch-up for pre-squash databases: give qe-front's attribution table its new name.
+
+Two unrelated tables were both called `question_attributions`, one per
+project: this repo's append-only log of inter-ministry reattributions, and
+qe-front's direction/bureau ground truth. Only ever one of them existed in
+any given database, so the collision stayed invisible.
+
+`62ff467c436e` settles it by creating both under distinct names. That
+covers databases created from now on. A database provisioned *before* it
+still holds qe-front's ground truth under the old name, while qe-front's
+code (`src/db/schema.ts`, the attribution routes) queries
+`question_real_attributions` — every attribution route fails at runtime
+with `42P01`.
+
+This migration is the catch-up path for those databases, and a no-op
+everywhere else:
+
+  - post-squash database: `question_real_attributions` already exists, the
+    guard short-circuits. The `question_attributions` sitting next to it is
+    the reattribution log, and is left alone — which is why the guard tests
+    for the *destination*, not just the source.
+  - pre-squash database: the only `question_attributions` present is
+    qe-front's ground truth, and it gets renamed.
+
+Nothing is dropped or rewritten either way, so it is reversible in one
+statement.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+revision: str = "e7f8a9b0c1d2"
+down_revision: Union[str, Sequence[str], None] = "62ff467c436e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # `to_regclass` resolves through `search_path` and returns NULL when the
+    # relation is absent. `pg_tables` would not do: it spans every schema, so
+    # an unrelated table of the same name elsewhere makes the guard read the
+    # wrong answer, while the bare ALTER below still targets whatever
+    # `search_path` resolves to.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('question_attributions') IS NOT NULL
+               AND to_regclass('question_real_attributions') IS NULL
+            THEN
+                ALTER TABLE question_attributions RENAME TO question_real_attributions;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('question_real_attributions') IS NOT NULL
+               AND to_regclass('question_attributions') IS NULL
+            THEN
+                ALTER TABLE question_real_attributions RENAME TO question_attributions;
+            END IF;
+        END $$;
+        """
+    )

--- a/tests/test_alembic_linear_history.py
+++ b/tests/test_alembic_linear_history.py
@@ -1,0 +1,60 @@
+"""Guard: the Alembic history must stay a single linear chain.
+
+`alembic upgrade head` (singular) is the documented and deployed command
+(README, CLAUDE.md, scripts/load_pgvector.py). It aborts with "Multiple
+head revisions are present" as soon as two migrations declare the same
+``down_revision`` and both land on main.
+
+Several feature branches add migrations in parallel, so this is a real
+failure mode: each branch is fine on its own, and the breakage only
+appears once the second one merges. GitHub runs PR checks against the
+prospective merge commit, so asserting it here turns a post-merge
+production incident into a red check on the second PR — at which point
+the fix is a one-line ``down_revision`` re-chain (or ``alembic merge``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _script_directory() -> ScriptDirectory:
+    config = Config(str(REPO_ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    return ScriptDirectory.from_config(config)
+
+
+def test_single_alembic_head() -> None:
+    heads = _script_directory().get_heads()
+    assert len(heads) == 1, (
+        "Alembic history has forked into several heads: "
+        f"{sorted(heads)}. `alembic upgrade head` cannot run. Re-chain the "
+        "newest migration's down_revision onto the other head."
+    )
+
+
+def test_every_revision_resolves() -> None:
+    """No migration may point at a down_revision that does not exist.
+
+    Catches the mirror-image mistake of the fork: re-chaining a branch
+    onto a revision that only exists in another, unmerged branch.
+    """
+    script = _script_directory()
+    known = {revision.revision for revision in script.walk_revisions()}
+    dangling = {
+        revision.revision: revision.down_revision
+        for revision in script.walk_revisions()
+        if revision.down_revision is not None
+        and not set(
+            revision.down_revision
+            if isinstance(revision.down_revision, tuple)
+            else (revision.down_revision,)
+        )
+        <= known
+    }
+    assert not dangling, f"Migrations pointing at unknown parents: {dangling}"


### PR DESCRIPTION
> **Réécrite après `cd83f3f` (squash de l'historique Alembic).** La version précédente présentait ceci comme un renommage et modifiait aussi `qe/models.py`. C'était faux : ce sont deux tables différentes. Ces changements sont retirés, il ne reste que la migration gardée.

## Le vrai problème

Deux tables sans rapport portaient le nom `question_attributions`, une par projet :

| Projet | Contenu |
|---|---|
| questions-ecrites | journal append-only des ré-attributions inter-ministères (`type_attribution`, `attributaire_id`) |
| qe-front | vérité terrain direction / bureau (`direction_reelle_id`, `bureau_reel_id`) |

Une base donnée n'en a jamais porté qu'une seule, la collision est donc restée invisible.

`62ff467c436e` la tranche en créant les deux sous des noms distincts — `question_attributions` pour le journal, `question_real_attributions` pour la vérité terrain. Cela couvre les bases créées à partir de maintenant.

## Ce que le squash ne couvre pas

Une base provisionnée **avant** garde la vérité terrain sous l'ancien nom, pendant que qe-front interroge `question_real_attributions` (`src/db/schema.ts` et les routes d'attribution). Toutes ces routes échouent en `42P01`.

Et le squash ne la rattrapera pas : ses 22 `op.create_table()` sont sans garde, c'est donc une migration d'installation neuve, jamais rejouée sur une base existante.

## La migration

No-op partout sauf là où c'est nécessaire :

- **base issue du squash** — `question_real_attributions` existe déjà, la garde court-circuite. Le `question_attributions` voisin est le journal, laissé intact. C'est pour ça que la garde teste la **destination**, pas seulement la source.
- **base antérieure** — le seul `question_attributions` présent est la vérité terrain, il est renommé.

`to_regclass` plutôt que `pg_tables` : il résout via le `search_path`, exactement comme l'`ALTER TABLE` non qualifié qui suit, donc garde et action portent forcément sur la même table.

## Garde-fou ajouté

`tests/test_alembic_linear_history.py` : une seule tête, et aucun `down_revision` orphelin. Plusieurs branches ajoutent une migration en parallèle ; chacune est valide isolément et la casse n'apparaît qu'au merge de la seconde. GitHub exécutant les checks sur le merge commit prévisionnel, le test passe au rouge **avant** le merge.

## Vérifié

Base de dev remise à `62ff467c436e`, table du journal créée, puis les routes applicatives :

```
GET /api/questions?limit=1                              → 200
GET /api/questions/AN-17-QE-3180                        → 200
GET /api/questions/AN-17-QE-3180/direction-attributions → 200  (DSS 93,3 % / DGOS 6,7 %)
```
