### PR TITLE
feat(db): colonnes contexte/question extraits (portage de qe-front#102)

### DIFF
--- a/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
+++ b/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
@@ -10,6 +10,12 @@ None of these columns are required for the app to work — they are
 additive structured metadata. NULL means "not yet analysed" or "the
 pattern did not match on this row"; consumers must degrade gracefully
 to the full `texte_question` when a column is NULL.
+
+`est_rappel` is NOT NULL DEFAULT FALSE on a ~260k-row table, which would
+be alarming on an older PostgreSQL. It is not here: since 11, a DEFAULT
+that is not volatile is recorded in the catalog and materialised lazily
+on read, so ADD COLUMN stays metadata-only — ACCESS EXCLUSIVE is held for
+that catalog update alone, with no table rewrite and no scan. We run 16.
 """
 
 from collections.abc import Sequence

--- a/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
+++ b/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
@@ -24,7 +24,7 @@ from typing import Union
 from alembic import op
 
 revision: str = "f1a2b3c4d5e6"
-down_revision: Union[str, Sequence[str], None] = "e7f8a9b0c1d2"
+down_revision: Union[str, Sequence[str], None] = "62ff467c436e"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
+++ b/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
@@ -1,0 +1,71 @@
+"""Add columns for the JO question parser output.
+
+Stores the result of running `qe.analysis.question_parser` on each row
+of `questions` (see the companion PR adding the analyser). Ported from
+the Drizzle migration originally opened as SocialGouv/qe-front#102:
+qe-front has since dropped its Drizzle setup ("let backend handle it"),
+so schema changes belong here.
+
+None of these columns are required for the app to work — they are
+additive structured metadata. NULL means "not yet analysed" or "the
+pattern did not match on this row"; consumers must degrade gracefully
+to the full `texte_question` when a column is NULL.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, Sequence[str], None] = "e7f8a9b0c1d2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE questions
+          ADD COLUMN IF NOT EXISTS contexte_extrait  TEXT,
+          ADD COLUMN IF NOT EXISTS question_extraite TEXT,
+          ADD COLUMN IF NOT EXISTS est_rappel        BOOLEAN NOT NULL DEFAULT FALSE,
+          ADD COLUMN IF NOT EXISTS analyzed_at       TIMESTAMPTZ
+        """
+    )
+    # Cheap partial index on the flag: lets us skip rappels from the
+    # embedding batch and from stats queries.
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_questions_est_rappel
+          ON questions (est_rappel)
+          WHERE est_rappel = TRUE
+        """
+    )
+    # Partial index used by the backfill mode of the analyser to find rows
+    # still needing parsing. We index `id`, not `analyzed_at`: every row
+    # matching the predicate has analyzed_at = NULL, so indexing the column
+    # itself would carry zero information, whereas indexing the PK lets the
+    # planner do an index-only scan on
+    # `SELECT id FROM questions WHERE analyzed_at IS NULL`.
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_questions_analyzed_at_null
+          ON questions (id)
+          WHERE analyzed_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_questions_analyzed_at_null")
+    op.execute("DROP INDEX IF EXISTS idx_questions_est_rappel")
+    op.execute(
+        """
+        ALTER TABLE questions
+          DROP COLUMN IF EXISTS analyzed_at,
+          DROP COLUMN IF EXISTS est_rappel,
+          DROP COLUMN IF EXISTS question_extraite,
+          DROP COLUMN IF EXISTS contexte_extrait
+        """
+    )

--- a/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
+++ b/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
@@ -24,7 +24,7 @@ from typing import Union
 from alembic import op
 
 revision: str = "f1a2b3c4d5e6"
-down_revision: Union[str, Sequence[str], None] = "62ff467c436e"
+down_revision: Union[str, Sequence[str], None] = "e7f8a9b0c1d2"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/qe/models.py
+++ b/qe/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     Text,
+    false,
     func,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -175,6 +176,20 @@ class Question(Base):
 
     # --- textes ---
     texte_question: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # --- analyse de texte_question (scripts/analyze_questions.py) ---
+    # Découpage contexte / demande réelle, et détection des rappels (une
+    # relance dont le texte n'est que « rappelle les termes de sa question »).
+    # analyzed_at reste NULL tant que la question n'a pas été analysée : c'est
+    # le curseur du backfill.
+    contexte_extrait: Mapped[str | None] = mapped_column(Text, nullable=True)
+    question_extraite: Mapped[str | None] = mapped_column(Text, nullable=True)
+    est_rappel: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=false()
+    )
+    analyzed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # --- réponse (None tant que EN_COURS) ---
     reponse_id: Mapped[str | None] = mapped_column(


### PR DESCRIPTION
## Pourquoi ici et plus dans qe-front

`qe-front` a supprimé son dispositif Drizzle (`refactor: Remove drizzle migrations and let backend handle it`). La migration de [qe-front#102](https://github.com/SocialGouv/qe-front/pull/102) est donc devenue orpheline — un fichier dans un dossier qui n'existe plus. Elle est portée ici, où vivent désormais les migrations.

**→ qe-front#102 devient sans objet et peut être fermée.**

## Contenu

Colonnes ajoutées sur `questions`, destinées à recevoir la sortie de l'analyseur régex (#41) :

| Colonne | Type | Rôle |
|---|---|---|
| `contexte_extrait` | TEXT | Le sujet abordé |
| `question_extraite` | TEXT | La demande réelle |
| `est_rappel` | BOOLEAN NOT NULL DEFAULT FALSE | Relance administrative |
| `analyzed_at` | TIMESTAMPTZ | NULL = jamais analysée |

Plus deux index partiels légers : filtrage des rappels, et scan de backfill (indexé sur `id` et non sur `analyzed_at`, dont la valeur est constante dans le sous-ensemble).

Tout est additif et idempotent. **NULL est un état valide** : les consommateurs doivent retomber sur `texte_question` complet.

## Dépendance

Chaînée après #48 (renommage `question_real_attributions`), qui corrige la régression actuelle de `main`.

## Vérification

- [x] `downgrade` puis `upgrade` → les 4 colonnes et les 2 index sont recréés
- [x] `pytest` 24/24

## Suite

L'UI correspondante est [qe-front#103](https://github.com/SocialGouv/qe-front/pull/103), inchangée — elle lit ces colonnes et gère déjà le repli sur NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)