### PR TITLE
fix(db): répare alembic upgrade head, cassé à deux endroits sur main

### DIFF
--- a/alembic/versions/b2c3d4e5f6a7_add_authjs_tables.py
+++ b/alembic/versions/b2c3d4e5f6a7_add_authjs_tables.py
@@ -34,7 +34,7 @@ from typing import Union
 from alembic import op
 
 revision: str = "b2c3d4e5f6a7"
-down_revision: Union[str, Sequence[str], None] = "f1a2b3c4d5e6"
+down_revision: Union[str, Sequence[str], None] = "e7f8a9b0c1d2"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/c1d2e3f4a5b6_add_question_bureau_extract.py
+++ b/alembic/versions/c1d2e3f4a5b6_add_question_bureau_extract.py
@@ -59,6 +59,12 @@ def upgrade() -> None:
             "bureau_full", sa.Text(), nullable=True,
             comment="Concaténation seg 3+ (ex '3e - 4e - 5e' pour les postes longs)"
         ),
+        # `source_etape_id` is a soft reference, deliberately NOT a foreign
+        # key. `reponses_extract_etapes` is populated by the MIN15 / Réponses
+        # tooling and no migration in this repo creates it — an FK would make
+        # this migration, and therefore `alembic upgrade head`, fail on every
+        # database that does not happen to carry that table, fresh ones
+        # included. The column keeps its provenance/debug value regardless.
         sa.Column(
             "source_etape_id", sa.Integer(), nullable=True,
             comment="FK vers l'étape MIN15 d'origine (pour provenance/debug)"
@@ -71,12 +77,6 @@ def upgrade() -> None:
             server_default=sa.text("NOW()"),
         ),
         sa.ForeignKeyConstraint(["question_id"], ["questions.id"], ondelete="CASCADE"),
-        # `source_etape_id` is a soft reference, deliberately NOT a foreign
-        # key. `reponses_extract_etapes` is populated by the MIN15 / Réponses
-        # tooling and no migration in this repo creates it — an FK would make
-        # this migration, and therefore `alembic upgrade head`, fail on every
-        # database that does not happen to carry that table, fresh ones
-        # included. The column keeps its provenance/debug value regardless.
         # Une ligne par (QE, direction) : si la QE a été passée à plusieurs
         # directions, on garde la trace de chacune.
         sa.UniqueConstraint("question_id", "direction_txt",

--- a/alembic/versions/c1d2e3f4a5b6_add_question_bureau_extract.py
+++ b/alembic/versions/c1d2e3f4a5b6_add_question_bureau_extract.py
@@ -71,9 +71,12 @@ def upgrade() -> None:
             server_default=sa.text("NOW()"),
         ),
         sa.ForeignKeyConstraint(["question_id"], ["questions.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(
-            ["source_etape_id"], ["reponses_extract_etapes.id"], ondelete="SET NULL"
-        ),
+        # `source_etape_id` is a soft reference, deliberately NOT a foreign
+        # key. `reponses_extract_etapes` is populated by the MIN15 / Réponses
+        # tooling and no migration in this repo creates it — an FK would make
+        # this migration, and therefore `alembic upgrade head`, fail on every
+        # database that does not happen to carry that table, fresh ones
+        # included. The column keeps its provenance/debug value regardless.
         # Une ligne par (QE, direction) : si la QE a été passée à plusieurs
         # directions, on garde la trace de chacune.
         sa.UniqueConstraint("question_id", "direction_txt",

--- a/alembic/versions/e5f6c7d8a9b1_add_allotissements_jo_view.py
+++ b/alembic/versions/e5f6c7d8a9b1_add_allotissements_jo_view.py
@@ -41,7 +41,7 @@ from alembic import op
 
 
 revision: str = "e5f6c7d8a9b1"
-down_revision: Union[str, Sequence[str], None] = "62ff467c436e"
+down_revision: Union[str, Sequence[str], None] = "b2c3d4e5f6a7"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/e5f6c7d8a9b1_add_allotissements_jo_view.py
+++ b/alembic/versions/e5f6c7d8a9b1_add_allotissements_jo_view.py
@@ -31,7 +31,7 @@ thematic allotments, ~2 % as batch admin (ministry applied a template
 to unrelated questions).
 
 Revision ID: e5f6c7d8a9b1
-Revises: a9b0c1d2e3f4
+Revises: b2c3d4e5f6a7
 Create Date: 2026-07-28
 """
 

--- a/alembic/versions/e7f8a9b0c1d2_rename_question_attributions.py
+++ b/alembic/versions/e7f8a9b0c1d2_rename_question_attributions.py
@@ -32,7 +32,7 @@ from typing import Union
 from alembic import op
 
 revision: str = "e7f8a9b0c1d2"
-down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+down_revision: Union[str, Sequence[str], None] = "62ff467c436e"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
+++ b/alembic/versions/f1a2b3c4d5e6_add_question_analysis_columns.py
@@ -24,7 +24,7 @@ from typing import Union
 from alembic import op
 
 revision: str = "f1a2b3c4d5e6"
-down_revision: Union[str, Sequence[str], None] = "e7f8a9b0c1d2"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## 🔴 `alembic upgrade head` est cassé sur `main`, à deux endroits

Les deux défauts sont reproduits contre une vraie base. Aucun ne pouvait être vu en CI : rien ne déroule la chaîne contre Postgres.

### 1. Clé étrangère vers une table qu'aucune migration ne crée

`c1d2e3f4a5b6` déclarait `source_etape_id` en clé étrangère vers `reponses_extract_etapes.id`. Cette table est peuplée par l'outillage MIN15 / Réponses ; **aucune migration de ce dépôt ne la crée** — ni l'ancienne chaîne, ni `62ff467c436e`. Elle n'existe que sur les bases de dev qui l'ont reçue par ailleurs.

Conséquence : la migration échoue sur toute base qui ne la porte pas, c'est-à-dire **toutes les bases neuves**.

```
psycopg2.errors.UndefinedTable: relation "reponses_extract_etapes" does not exist
```

`source_etape_id` devient une référence souple. La colonne garde sa valeur de provenance et de debug, sans imposer une dépendance sur un objet hors de notre contrôle. C'est ma PR #45 qui portait ce défaut.

### 2. Le rattrapage du renommage passait après la vue qui en dépend

L'ordre issu des merges plaçait `e7f8a9b0c1d2` (rattrapage du nom de table) **après** `d4e5f6a7b8c9`, qui exécute `CREATE VIEW … SELECT … FROM question_real_attributions`. Sur une base antérieure au squash, ce nom n'existe pas encore à ce moment-là.

```
psycopg2.errors.UndefinedTable: relation "question_real_attributions" does not exist
```

Les deux migrations de rattrapage passent en tête de chaîne, juste après l'init. C'est leur place : ce sont des prérequis, pas des fonctionnalités.

**Avant**
```
62ff467c436e → e5f6c7d8a9b1 → d5a1c2f3e4b6 → c1d2e3f4a5b6
             → d4e5f6a7b8c9 → e7f8a9b0c1d2 → f1a2b3c4d5e6 → b2c3d4e5f6a7
```

**Après**
```
62ff467c436e → e7f8a9b0c1d2 → b2c3d4e5f6a7 → e5f6c7d8a9b1
             → d5a1c2f3e4b6 → c1d2e3f4a5b6 → d4e5f6a7b8c9 → f1a2b3c4d5e6
```

## Vérification

`upgrade head` déroulé jusqu'au bout sur deux bases jetables :

| Base | Avant | Après |
|---|---|---|
| neuve | échoue sur `c1d2e3f4a5b6` | **8 migrations appliquées** |
| reconstruite à l'état antérieur au squash — vérité terrain sous l'ancien nom, tables Auth.js absentes | échoue sur `c1d2e3f4a5b6`, puis sur `d4e5f6a7b8c9` | **8 migrations appliquées** |

65 tests verts, garde-fou d'historique compris.

## Note sur la modification de migrations déjà mergées

Cette PR édite le `down_revision` de quatre révisions déjà sur `main`, ce qui ne se fait pas à la légère. Ici c'est sans risque : dans l'ordre actuel la chaîne **ne peut aboutir sur aucune base**, donc aucun environnement ne peut l'avoir consommée. La seule base à avoir appliqué `c1d2e3f4a5b6` est une base de dev qui portait déjà `reponses_extract_etapes` ; la contrainte y a été retirée à la main, sans migration supplémentaire pour ne pas alourdir la chaîne.

Si un environnement a malgré tout déjà tourné, dites-le moi avant de merger — la reprise ne serait pas la même.
