### PR TITLE
ci: bump cronjob-ingestion.yaml tag alongside deployment.yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,10 +49,10 @@ deploy:argocd:
   script:
     - git clone --depth 1 "https://oauth2:${ARGO_REPO_TOKEN}@pic.sg.social.gouv.fr/socialgouv/data-ia/data-platform/data-platform-argocd.git"
     - cd data-platform-argocd
-    - sed -i -E "s|(image. pic-registry.sg.social.gouv.fr/socialgouv/data-ia/data-platform/questions-ecrites-back).*|\1:${CI_COMMIT_SHORT_SHA}|" questions-ecrites/deployment.yaml
+    - sed -i -E "s|(image. pic-registry.sg.social.gouv.fr/socialgouv/data-ia/data-platform/questions-ecrites-back).*|\1:${CI_COMMIT_SHORT_SHA}|" questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml
     - git config user.name "ci-questions-ecrites-back"
     - git config user.email "ci@pic.sg.social.gouv.fr"
-    - git add questions-ecrites/deployment.yaml
+    - git add questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml
     - git diff --cached --quiet || (git commit -m "questions-ecrites-back:${CI_COMMIT_SHORT_SHA}" && git push origin main)
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,8 @@ deploy:argocd:
   script:
     - git clone --depth 1 "https://oauth2:${ARGO_REPO_TOKEN}@pic.sg.social.gouv.fr/socialgouv/data-ia/data-platform/data-platform-argocd.git"
     - cd data-platform-argocd
-    - sed -i -E "s|(image. pic-registry.sg.social.gouv.fr/socialgouv/data-ia/data-platform/questions-ecrites-back).*|\1:${CI_COMMIT_SHORT_SHA}|" questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml
+    - test -f questions-ecrites/cronjob-ingestion.yaml || { echo "questions-ecrites/cronjob-ingestion.yaml not found in data-platform-argocd"; exit 1; }
+    - sed -i -E "s|(image: pic-registry.sg.social.gouv.fr/socialgouv/data-ia/data-platform/questions-ecrites-back).*|\1:${CI_COMMIT_SHORT_SHA}|" questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml
     - git config user.name "ci-questions-ecrites-back"
     - git config user.email "ci@pic.sg.social.gouv.fr"
     - git add questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml


### PR DESCRIPTION
## Summary
- `deploy:argocd` only bumped `deployment.yaml`'s image tag, so the `qe-ingestion` cronjob (pinned separately in `data-platform-argocd`) could drift ahead of whatever migration was actually applied, crashing the daily run on schema it didn't have yet.
- Extends the same `sed` to also bump `cronjob-ingestion.yaml`, keeping it in lockstep with `back` automatically. `migration-job.yaml` stays manually maintained on purpose (human review before a migration runs).

## Test plan
- [x] Companion pin already applied directly in `data-platform-argocd` (separate MR) to fix the current drift; this PR keeps it from recurring on every future deploy