### PR TITLE
fix(db): repair broken migration chain + recreate missing attribution objects

### DIFF
--- a/alembic/versions/087d1c73ddbc_upgrade_pgvector_extension_to_the_.py
+++ b/alembic/versions/087d1c73ddbc_upgrade_pgvector_extension_to_the_.py
@@ -1,0 +1,56 @@
+"""upgrade pgvector extension to the version bundled in the postgres image
+
+qe-front's attribution routes (see `src/lib/similarity/knn-vote.ts`,
+`withHnswSearch`) run `SET LOCAL hnsw.iterative_scan = strict_order`, a GUC
+pgvector only exposes from 0.8.0 onward. On Atlas Sandbox the `vector`
+extension was created (at bootstrap time, `postInitApplicationSQL`) when
+the postgres image only bundled pgvector 0.6.0 -- `CREATE EXTENSION`
+installed 0.6.0 and it was never revisited, so every attribution query
+fails with "unrecognized configuration parameter" even once the
+`question_attributions_all` view exists.
+
+`ALTER EXTENSION vector UPDATE` (no target version) upgrades to whatever
+version is bundled in the *currently running* postgres image, alongside
+the `imageName` bump in `data-platform-argocd/questions-ecrites/postgres.yaml`
+(confirmed locally: `ghcr.io/cloudnative-pg/postgresql:16.8` bundles
+pgvector 0.8.0, vs. 0.6.0 in the `16.1` this cluster runs today).
+
+This statement is a safe no-op in two cases that matter here:
+  - already at the latest bundled version (confirmed locally: emits a
+    NOTICE, no error, `extversion` unchanged);
+  - the postgres image hasn't been bumped yet, i.e. `pg_available_extension_versions`
+    still tops out at 0.6.0 -- `UPDATE` then targets 0.6.0, which is also a
+    no-op. This migration is safe to ship and deploy independently of the
+    image bump landing; whichever deploy (this migration's image, or the
+    postgres image bump) lands second is the one that actually performs
+    the upgrade.
+
+Revision ID: 087d1c73ddbc
+Revises: 6cee3d0e7f23
+Create Date: 2026-08-21 18:41:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "087d1c73ddbc"
+down_revision: Union[str, Sequence[str], None] = "6cee3d0e7f23"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("ALTER EXTENSION vector UPDATE")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Downgrading a shared, cluster-wide extension version on request of a
+    # single app's migration history is not something we want to automate:
+    # other tables' hnsw indexes may already depend on behaviour from the
+    # newer version. No-op, same reasoning as 6cee3d0e7f23's downgrade.
+    pass

--- a/alembic/versions/4bcdeece2262_merge_heads_jo_parser_columns_office_.py
+++ b/alembic/versions/4bcdeece2262_merge_heads_jo_parser_columns_office_.py
@@ -1,0 +1,33 @@
+"""merge heads: JO parser columns + office-attribution removal
+
+`main` had two divergent heads (`alembic heads` failing with "Multiple head
+revisions are present") since the JO-parser-columns branch (`f1a2b3c4d5e6`)
+and the office-attribution-removal branch (`f972851671ad`) both merged
+independently without reconciling the migration DAG — both branch off
+`b2c3d4e5f6a7` and neither touches an object the other cares about, so a
+plain no-op merge revision is sufficient; there's no DDL to reconcile.
+
+Revision ID: 4bcdeece2262
+Revises: f1a2b3c4d5e6, f972851671ad
+Create Date: 2026-08-21 18:37:08.619499
+
+"""
+
+from typing import Sequence, Union
+
+
+# revision identifiers, used by Alembic.
+revision: str = "4bcdeece2262"
+down_revision: Union[str, Sequence[str], None] = ("f1a2b3c4d5e6", "f972851671ad")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/alembic/versions/6cee3d0e7f23_catch_up_for_pre_squash_databases_.py
+++ b/alembic/versions/6cee3d0e7f23_catch_up_for_pre_squash_databases_.py
@@ -1,0 +1,171 @@
+"""catch-up for pre-squash databases: recreate bureau-attribution view chain
+
+Some databases have their `alembic_version` stamped past `e5f6c7d8a9b1`
+(allotissements_jo), `c1d2e3f4a5b6` (question_bureau_extract) and/or
+`d4e5f6a7b8c9` (question_attributions_all) without those migrations' DDL
+ever having actually run — same root cause as the pre-squash catch-ups in
+`e7f8a9b0c1d2` and `b2c3d4e5f6a7`. Confirmed on the Atlas Sandbox database:
+`alembic_version` was already at `b2c3d4e5f6a7`, yet `to_regclass(...)`
+returned NULL for all three objects while later-in-chain objects
+(direction_algo_id, the JO parser columns, the Auth.js tables) were
+present. Alembic never re-runs a migration once it believes the stamp is
+past it, so a plain `alembic upgrade head` cannot self-heal this — hence
+this catch-up, which every already-consistent database (this branch's own
+dev/CI databases included) runs as a no-op.
+
+Everything below is guarded to be safe on a database that already has
+these objects (post-squash, or a database where these migrations did run
+normally):
+
+  - `allotissements_jo`: `CREATE OR REPLACE VIEW`, verbatim from
+    `e5f6c7d8a9b1` — already idempotent by construction.
+  - `question_bureau_extract`: `CREATE TABLE IF NOT EXISTS` +
+    `CREATE INDEX IF NOT EXISTS`, same shape as `c1d2e3f4a5b6` on main
+    (`source_etape_id` has no foreign key — it's a deliberate soft
+    reference to the externally-loaded `reponses_extract_etapes`, never
+    an FK; see that migration's comment).
+  - `question_attributions_all`: `CREATE OR REPLACE VIEW`, verbatim from
+    `d4e5f6a7b8c9`. Requires `question_bureau_extract` to exist (it's
+    referenced in the view's MIN15-side CTE), hence the ordering below.
+
+downgrade() is intentionally a no-op: on a database where this migration
+was a no-op upgrade (objects pre-existed), downgrading would destroy
+objects that predate this migration and that other code may depend on.
+There's no way from here to tell "created by this migration" apart from
+"already there" after the fact, so the safe default is to leave state
+alone — consistent with the same trade-off made in `e7f8a9b0c1d2`.
+
+Revision ID: 6cee3d0e7f23
+Revises: 4bcdeece2262
+Create Date: 2026-08-21 18:40:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6cee3d0e7f23"
+down_revision: Union[str, Sequence[str], None] = "4bcdeece2262"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+ALLOTISSEMENTS_JO_VIEW_DDL = """
+CREATE OR REPLACE VIEW allotissements_jo AS
+SELECT
+    r.id                    AS allotissement_id,
+    r.source                AS source,
+    r.date_reponse_jo       AS date_jo,
+    r.no_publication        AS no_publication,
+    r.ministre_reponse_libelle AS ministre_reponse,
+    COUNT(q.id)             AS n_questions,
+    ARRAY_AGG(q.id ORDER BY q.id) AS question_ids,
+    r.texte_reponse         AS texte_reponse
+FROM reponses r
+JOIN questions q ON q.reponse_id = r.id
+GROUP BY r.id, r.source, r.date_reponse_jo, r.no_publication,
+         r.ministre_reponse_libelle, r.texte_reponse
+HAVING COUNT(q.id) >= 2
+"""
+
+QUESTION_BUREAU_EXTRACT_DDL = """
+CREATE TABLE IF NOT EXISTS question_bureau_extract (
+    id SERIAL PRIMARY KEY,
+    question_id VARCHAR(100) NOT NULL
+        REFERENCES questions(id) ON DELETE CASCADE,
+    direction_txt TEXT NOT NULL,
+    sous_direction TEXT,
+    bureau TEXT,
+    bureau_full TEXT,
+    source_etape_id INTEGER,
+    date_debut_etape DATE,
+    extracted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_question_bureau_extract_qid_dir
+        UNIQUE (question_id, direction_txt)
+);
+CREATE INDEX IF NOT EXISTS ix_question_bureau_extract_qid
+    ON question_bureau_extract (question_id);
+CREATE INDEX IF NOT EXISTS ix_question_bureau_extract_direction
+    ON question_bureau_extract (direction_txt);
+COMMENT ON TABLE question_bureau_extract IS
+    'Bureau reel extrait des workflows MIN15 (outil Reponses). '
+    'Source complementaire a question_real_attributions.bureau_reel_id '
+    'qui n''est peuplee que pour DGCS. Voir '
+    'scripts/extract_bureau_from_min15.py pour la regle d''extraction.'
+"""
+
+QUESTION_ATTRIBUTIONS_ALL_VIEW_DDL = r"""
+CREATE OR REPLACE VIEW question_attributions_all AS
+WITH attribution_rows AS (
+    SELECT
+        qa.question_id,
+        UPPER(REPLACE((regexp_match(b.nom, '^\s*\[([^\]]+)\]'))[1], ' ', ''))
+            AS bureau_key,
+        b.nom AS bureau_label,
+        d.nom AS direction_label,
+        'attribution'::text AS source
+    FROM question_real_attributions qa
+    JOIN bureaux b ON b.id = qa.bureau_reel_id
+    LEFT JOIN directions d ON d.id = b.direction_id
+    WHERE qa.bureau_reel_id IS NOT NULL
+      AND b.nom ~ '^\s*\[[^\]]+\]'
+),
+min15_rows AS (
+    SELECT DISTINCT ON (e.question_id)
+        e.question_id,
+        UPPER(REPLACE(BTRIM(e.sous_direction), ' ', ''))
+          || CASE
+               WHEN e.bureau IS NULL OR BTRIM(e.bureau) = '' THEN ''
+               WHEN (regexp_match(e.bureau, '^\s*Bureau\s+(\w+)', 'i'))
+                    IS NOT NULL
+                 THEN '/' || UPPER(
+                     (regexp_match(e.bureau, '^\s*Bureau\s+(\w+)', 'i'))[1])
+               ELSE COALESCE(
+                 '/' || NULLIF(UPPER(
+                     (regexp_split_to_array(BTRIM(e.bureau), '[\s/,-]+'))[1]),
+                     ''),
+                 '')
+             END AS bureau_key,
+        BTRIM(CONCAT_WS(' — ',
+            NULLIF(BTRIM(e.sous_direction), ''),
+            NULLIF(BTRIM(COALESCE(e.bureau_full, e.bureau)), '')))
+            AS bureau_label,
+        e.direction_txt AS direction_label,
+        'min15'::text AS source
+    FROM question_bureau_extract e
+    WHERE e.sous_direction IS NOT NULL AND BTRIM(e.sous_direction) <> ''
+      AND NOT EXISTS (
+            SELECT 1
+            FROM question_real_attributions qa2
+            JOIN bureaux b2 ON b2.id = qa2.bureau_reel_id
+            WHERE qa2.question_id = e.question_id
+              AND b2.nom ~ '^\s*\[[^\]]+\]'
+      )
+    ORDER BY e.question_id, e.date_debut_etape DESC NULLS LAST, e.id
+)
+SELECT question_id,
+       bureau_key,
+       COALESCE(NULLIF(bureau_label, ''), bureau_key) AS bureau_label,
+       direction_label,
+       source
+FROM (
+    SELECT * FROM attribution_rows
+    UNION ALL
+    SELECT * FROM min15_rows
+) unioned
+WHERE bureau_key IS NOT NULL AND bureau_key <> ''
+"""
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute(ALLOTISSEMENTS_JO_VIEW_DDL)
+    op.execute(QUESTION_BUREAU_EXTRACT_DDL)
+    op.execute(QUESTION_ATTRIBUTIONS_ALL_VIEW_DDL)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
+++ b/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
@@ -21,13 +21,20 @@ only adds the columns; scripts and wiring live in the qe-front repo.
 Revision ID: d5a1c2f3e4b6
 Revises: e5f6c7d8a9b1
 Create Date: 2026-07-18
+
+Made idempotent after the fact: the `fix/migration-chain-order` rechain
+moved this migration from before to after `b2c3d4e5f6a7` in the DAG.
+Atlas Sandbox had already run it (under the old order) by the time that
+rechain landed, so its stamp (`b2c3d4e5f6a7`) now sits *before* this
+migration instead of after it — a plain `alembic upgrade head` would try
+to add `direction_algo_id` again and fail with `DuplicateColumn`. Every
+statement below is guarded so this is a no-op there and unchanged
+everywhere else.
 """
 
 from typing import Sequence, Union
 
-import sqlalchemy as sa
 from alembic import op
-
 
 revision: str = "d5a1c2f3e4b6"
 down_revision: Union[str, Sequence[str], None] = "e5f6c7d8a9b1"
@@ -37,38 +44,41 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # Nullable — most questions will be NULL until the backfill runs.
-    # FK constraint is explicitly named so re-runs don't create silent
-    # duplicates and downgrade() knows what to drop.
-    op.add_column(
-        "questions",
-        sa.Column(
-            "direction_algo_id",
-            sa.Integer(),
-            sa.ForeignKey(
-                "directions.id",
-                name="fk_questions_direction_algo_id",
-                ondelete="SET NULL",
-            ),
-            nullable=True,
-        ),
+    op.execute(
+        """
+        ALTER TABLE questions
+          ADD COLUMN IF NOT EXISTS direction_algo_id INTEGER,
+          ADD COLUMN IF NOT EXISTS direction_algo_computed_at TIMESTAMPTZ
+        """
     )
-    op.add_column(
-        "questions",
-        sa.Column(
-            "direction_algo_computed_at",
-            sa.DateTime(timezone=True),
-            nullable=True,
-        ),
+    # FK constraint explicitly named so re-runs don't create silent
+    # duplicates and downgrade() knows what to drop.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_questions_direction_algo_id'
+            ) THEN
+                ALTER TABLE questions
+                    ADD CONSTRAINT fk_questions_direction_algo_id
+                    FOREIGN KEY (direction_algo_id)
+                    REFERENCES directions(id) ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
     )
     # Partial index — skip the ~260k NULL rows we'll have between the
     # migration and the first backfill run. The filter predicate we
     # care about is always `direction_algo_id = X` (or IN (…)), so NULL
     # rows in the index are pure overhead.
-    op.create_index(
-        "ix_questions_direction_algo_id",
-        "questions",
-        ["direction_algo_id"],
-        postgresql_where=sa.text("direction_algo_id IS NOT NULL"),
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_questions_direction_algo_id
+            ON questions (direction_algo_id)
+            WHERE direction_algo_id IS NOT NULL
+        """
     )
 
 

--- a/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
+++ b/alembic/versions/d5a1c2f3e4b6_add_direction_algo_cache.py
@@ -83,6 +83,16 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index("ix_questions_direction_algo_id", table_name="questions")
-    op.drop_column("questions", "direction_algo_computed_at")
-    op.drop_column("questions", "direction_algo_id")
+    # IF EXISTS for the same reason upgrade() is guarded: on a database
+    # that reached this revision via the old chain order (Atlas Sandbox),
+    # alembic's own bookkeeping is the only thing that says these objects
+    # belong to this migration — plain op.drop_* would error if downgrade
+    # is ever invoked from a state where upgrade() ran as a no-op.
+    op.execute("DROP INDEX IF EXISTS ix_questions_direction_algo_id")
+    op.execute(
+        """
+        ALTER TABLE questions
+          DROP COLUMN IF EXISTS direction_algo_computed_at,
+          DROP COLUMN IF EXISTS direction_algo_id
+        """
+    )


### PR DESCRIPTION
## Summary

qe-front's `/api/questions/[id]/attributions` route was failing on Atlas Sandbox. Root cause: `alembic_version` is stamped past several migrations whose DDL never actually ran there (`allotissements_jo`, `question_bureau_extract`, `question_attributions_all` are all missing despite later-in-chain objects existing). On top of that, `main` currently has two diverged alembic heads and one already-applied migration (`d5a1c2f3e4b6`) that the recent chain-order rechain repositioned *after* the sandbox's stamp, which would make `alembic upgrade head` fail with `DuplicateColumn` on next deploy.

- `4bcdeece2262`: merge the two diverged heads (`f1a2b3c4d5e6`, `f972851671ad`) — no-op DDL, unrelated objects.
- `503c869` (`d5a1c2f3e4b6`): make the `direction_algo_id` cache migration idempotent — it already ran on sandbox under the old chain order.
- `6cee3d0e7f23`: catch-up migration recreating `allotissements_jo`, `question_bureau_extract`, `question_attributions_all` — guarded no-op everywhere they already exist.
- `087d1c73ddbc`: `ALTER EXTENSION vector UPDATE`, paired with the postgres image bump in `data-platform-argocd` (pgvector 0.6.0 → 0.8.0, needed for the `hnsw.iterative_scan` GUC the attribution route uses).

## Test plan

All four migrations were run against a local Postgres, including faithfully reproducing Atlas Sandbox's exact partial state (stamped at `b2c3d4e5f6a7`, with `direction_algo_id`/JO columns/FK/index already present, the three attribution objects missing) and confirming `alembic upgrade head` completes cleanly and recreates them:

- [x] Fresh database, full chain from `init schema` to head — no errors
- [x] Simulated sandbox state (stamped past, objects dropped) — catch-up migration repairs it
- [x] Re-run on an already-consistent database — confirmed no-op (no errors, no changes)
- [x] `ruff check` / `ruff format --check` / `mypy` / `pytest` all pass on the changed files