### PR TITLE
fix(ci): bump migration-job.yaml's image tag on deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,10 +50,11 @@ deploy:argocd:
     - git clone --depth 1 "https://oauth2:${ARGO_REPO_TOKEN}@pic.sg.social.gouv.fr/socialgouv/data-ia/data-platform/data-platform-argocd.git"
     - cd data-platform-argocd
     - test -f questions-ecrites/cronjob-ingestion.yaml || { echo "questions-ecrites/cronjob-ingestion.yaml not found in data-platform-argocd"; exit 1; }
-    - sed -i -E "s|(image: pic-registry.sg.social.gouv.fr/socialgouv/data-ia/data-platform/questions-ecrites-back).*|\1:${CI_COMMIT_SHORT_SHA}|" questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml
+    - test -f questions-ecrites/migration-job.yaml || { echo "questions-ecrites/migration-job.yaml not found in data-platform-argocd"; exit 1; }
+    - sed -i -E "s|(image: pic-registry.sg.social.gouv.fr/socialgouv/data-ia/data-platform/questions-ecrites-back).*|\1:${CI_COMMIT_SHORT_SHA}|" questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml questions-ecrites/migration-job.yaml
     - git config user.name "ci-questions-ecrites-back"
     - git config user.email "ci@pic.sg.social.gouv.fr"
-    - git add questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml
+    - git add questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml questions-ecrites/migration-job.yaml
     - git diff --cached --quiet || (git commit -m "questions-ecrites-back:${CI_COMMIT_SHORT_SHA}" && git push origin main)
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,12 +49,20 @@ deploy:argocd:
   script:
     - git clone --depth 1 "https://oauth2:${ARGO_REPO_TOKEN}@pic.sg.social.gouv.fr/socialgouv/data-ia/data-platform/data-platform-argocd.git"
     - cd data-platform-argocd
-    - test -f questions-ecrites/cronjob-ingestion.yaml || { echo "questions-ecrites/cronjob-ingestion.yaml not found in data-platform-argocd"; exit 1; }
-    - test -f questions-ecrites/migration-job.yaml || { echo "questions-ecrites/migration-job.yaml not found in data-platform-argocd"; exit 1; }
-    - sed -i -E "s|(image: pic-registry.sg.social.gouv.fr/socialgouv/data-ia/data-platform/questions-ecrites-back).*|\1:${CI_COMMIT_SHORT_SHA}|" questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml questions-ecrites/migration-job.yaml
+    # Every manifest that pins this image's tag. Kept as one list so all
+    # three stay in lockstep by construction — migration-job.yaml silently
+    # drifting out of this list is exactly what this pipeline was missing.
+    - MANIFESTS="questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml questions-ecrites/migration-job.yaml"
+    - for f in $MANIFESTS; do test -f "$f" || { echo "$f not found in data-platform-argocd"; exit 1; }; done
+    - sed -i -E "s|(image: pic-registry.sg.social.gouv.fr/socialgouv/data-ia/data-platform/questions-ecrites-back).*|\1:${CI_COMMIT_SHORT_SHA}|" $MANIFESTS
+    # sed exits 0 even when the pattern matches nothing, so a silent no-op
+    # (e.g. the image name prefix changes) would otherwise push a partial,
+    # inconsistent update with no CI failure — assert every file actually
+    # got the new tag.
+    - for f in $MANIFESTS; do grep -q "questions-ecrites-back:${CI_COMMIT_SHORT_SHA}" "$f" || { echo "sed did not update the image tag in $f"; exit 1; }; done
     - git config user.name "ci-questions-ecrites-back"
     - git config user.email "ci@pic.sg.social.gouv.fr"
-    - git add questions-ecrites/deployment.yaml questions-ecrites/cronjob-ingestion.yaml questions-ecrites/migration-job.yaml
+    - git add $MANIFESTS
     - git diff --cached --quiet || (git commit -m "questions-ecrites-back:${CI_COMMIT_SHORT_SHA}" && git push origin main)
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"


### PR DESCRIPTION
## Summary

`deploy:argocd` sed-replaces the backend image tag in `deployment.yaml` and `cronjob-ingestion.yaml` on every push to main, but never touched `migration-job.yaml` (the ArgoCD PreSync hook that runs `alembic upgrade head`). Its tag has been frozen at `f22b2889` since it was added — confirmed via `data-platform-argocd` history: `deployment.yaml`/`cronjob-ingestion.yaml` show dozens of CI auto-bump commits, `migration-job.yaml` shows only its 3 original manual commits.

Net effect: the migration Job has been running on every sync like it's supposed to, but always against a frozen, increasingly stale version of the Alembic chain — it has no idea about any migration merged since that tag was built. This is why Atlas Sandbox ended up several migrations behind despite the PreSync hook existing specifically to prevent that (see the incident note in `migration-job.yaml`'s header).

## Change

Add `questions-ecrites/migration-job.yaml` to the existing `test -f` guard, `sed` file list, and `git add` in `deploy:argocd`, so its tag stays in lockstep with `deployment.yaml`/`cronjob-ingestion.yaml`.

## Test plan

- [x] Validated the YAML still parses
- [x] Ran the exact `sed` command (GNU sed, matching the Alpine CI image) against a copy of the real `migration-job.yaml` — confirmed the image line updates correctly
- [ ] First real deploy after merge will confirm end-to-end (can't dry-run GitLab CI itself from here)