### PR TITLE
fix(ingestion): bound Sénat ingestion memory to avoid OOM

### DIFF
--- a/qe/hashing.py
+++ b/qe/hashing.py
@@ -9,7 +9,10 @@ from uuid import UUID
 
 
 def hash_file(path: Path) -> str:
-    """SHA-256 hash of a file's contents, read in chunks (not loaded fully into memory)."""
+    """SHA-256 hash of a file's contents, read in chunks (not loaded fully into memory).
+
+    Uses ``hashlib.file_digest`` (Python >= 3.11; this project requires >= 3.12).
+    """
     with path.open("rb") as f:
         return hashlib.file_digest(f, "sha256").hexdigest()
 

--- a/qe/hashing.py
+++ b/qe/hashing.py
@@ -8,6 +8,12 @@ from pathlib import Path
 from uuid import UUID
 
 
+def hash_file(path: Path) -> str:
+    """SHA-256 hash of a file's contents, read in chunks (not loaded fully into memory)."""
+    with path.open("rb") as f:
+        return hashlib.file_digest(f, "sha256").hexdigest()
+
+
 def stable_point_id(path: Path) -> str:
     """Deterministic UUID for a document path."""
     digest = hashlib.sha256(str(path.resolve()).encode("utf-8")).hexdigest()

--- a/qe/ingestion_senat.py
+++ b/qe/ingestion_senat.py
@@ -25,7 +25,7 @@ Key conventions:
   - ``reponse_id`` uses a synthetic key ``"SENAT-DUMP-{qid}"`` (no JO page
     number is available in this dump).
   - Theme codes (``#2#14#`` format) are resolved to labels via the ``the``
-    lookup table, which is parsed in the same single pass.
+    lookup table, parsed in the same pass as ``tam_questions``.
 """
 
 from __future__ import annotations
@@ -37,7 +37,7 @@ import zipfile
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import IO
+from typing import IO, Callable, Iterator
 
 from qe.ingestion_an import (
     IngestStats,
@@ -166,88 +166,87 @@ class _PartialQ:
 
 
 # ---------------------------------------------------------------------------
-# Single-pass parser
+# Two-pass parser
 # ---------------------------------------------------------------------------
 
 
-def parse_senat_sql_dump(sql_file: IO[bytes]) -> list[ParsedQuestion]:  # noqa: C901
-    """Stream-parse a Sénat pg_dump file, returning QE questions from leg 14 onward.
+def _stream_copy_blocks(
+    open_stream: Callable[[], IO[bytes]],
+) -> Iterator[tuple[str, dict[str, int], list[str]]]:
+    """Yield ``(table_name, col_idx, fields)`` for every data row in every COPY block.
 
-    Performs a single pass over the dump collecting:
-      - ``sortquestion``  → sort_map  (sorquecod → status label)
-      - ``tam_questions`` → partial question rows (filtered to QE + leg >= 14)
-      - ``tam_reponses``  → responses dict (question id → response data)
-      - ``the``           → theme_map (thecle → thelib)
-
-    After the pass, question rows are enriched with response text and resolved
-    theme labels, then converted to ``ParsedQuestion`` objects.
+    Opens a fresh stream each call so callers can iterate the dump more than
+    once (e.g. one pass per table of interest) without holding it in memory.
     """
-    sort_map: dict[str, str] = {}  # sorquecod → sorquelib
-    theme_map: dict[str, str] = {}  # str(thecle) → thelib
-    responses: dict[str, tuple] = {}  # str(idque) → (txtrep, datejorep, minreplib)
+    with open_stream() as sql_file:
+        reader = io.TextIOWrapper(sql_file, encoding="utf-8", errors="surrogateescape")
+        current_table: str | None = None
+        current_cols: dict[str, int] = {}
+
+        for raw_line in reader:
+            line = raw_line.rstrip("\n")
+
+            if current_table is None:
+                m = _COPY_RE.match(line)
+                if m:
+                    # Strip schema prefix ("questions.tam_questions" → "tam_questions")
+                    full_name = m.group(1)
+                    table_name = full_name.split(".")[-1]
+                    cols = [c.strip().strip('"') for c in m.group(2).split(",")]
+                    current_cols = {name: idx for idx, name in enumerate(cols)}
+                    current_table = table_name
+
+                    if table_name == "tam_questions":
+                        missing = _EXPECTED_COLS - set(current_cols)
+                        if missing:
+                            logger.warning(
+                                "Sénat dump: tam_questions is missing expected columns: %s",
+                                ", ".join(sorted(missing)),
+                            )
+                        logger.debug("tam_questions COPY block: %d columns", len(cols))
+                continue
+
+            if line == "\\.":
+                current_table = None
+                current_cols = {}
+                continue
+
+            yield current_table, current_cols, line.split("\t")
+
+
+def _parse_lookups_and_questions(  # noqa: C901
+    open_stream: Callable[[], IO[bytes]],
+) -> tuple[dict[str, str], dict[str, str], list[_PartialQ]]:
+    """Pass 1: ``sortquestion``, ``the``, and filtered ``tam_questions`` rows.
+
+    ``tam_reponses`` is skipped here — it's read separately in pass 2, once
+    the set of question ids we actually care about is known, so that dict
+    never has to hold response rows for the full 1978-present history.
+    """
+    sort_map: dict[str, str] = {}
+    theme_map: dict[str, str] = {}
     partial: list[_PartialQ] = []
 
-    reader = io.TextIOWrapper(sql_file, encoding="utf-8", errors="surrogateescape")
-    current_table: str | None = None
-    current_cols: dict[str, int] = {}
-
-    for raw_line in reader:
-        line = raw_line.rstrip("\n")
-
-        if current_table is None:
-            m = _COPY_RE.match(line)
-            if m:
-                # Strip schema prefix (e.g. "questions.tam_questions" → "tam_questions")
-                full_name = m.group(1)
-                table_name = full_name.split(".")[-1]
-                cols = [c.strip().strip('"') for c in m.group(2).split(",")]
-                current_cols = {name: idx for idx, name in enumerate(cols)}
-                current_table = table_name
-
-                if table_name == "tam_questions":
-                    missing = _EXPECTED_COLS - set(current_cols)
-                    if missing:
-                        logger.warning(
-                            "Sénat dump: tam_questions is missing expected columns: %s",
-                            ", ".join(sorted(missing)),
-                        )
-                    logger.debug("tam_questions COPY block: %d columns", len(cols))
-            continue
-
-        if line == "\\.":
-            current_table = None
-            current_cols = {}
-            continue
-
-        fields = line.split("\t")
-
-        if current_table == "sortquestion":
-            code = _get(fields, current_cols, "sorquecod")
-            lib = _get(fields, current_cols, "sorquelib")
+    for table, cols, fields in _stream_copy_blocks(open_stream):
+        if table == "sortquestion":
+            code = _get(fields, cols, "sorquecod")
+            lib = _get(fields, cols, "sorquelib")
             if code and lib:
                 sort_map[code] = lib
 
-        elif current_table == "the":
-            cle = _get(fields, current_cols, "thecle")
-            lib = _get(fields, current_cols, "thelib")
+        elif table == "the":
+            cle = _get(fields, cols, "thecle")
+            lib = _get(fields, cols, "thelib")
             if cle and lib:
                 theme_map[cle] = lib
 
-        elif current_table == "tam_reponses":
-            idque = _get(fields, current_cols, "idque")
-            txtrep = _get(fields, current_cols, "txtrep")
-            datejorep = _get(fields, current_cols, "datejorep")
-            minreplib = _get(fields, current_cols, "minreplib")
-            if idque:
-                responses[idque] = (txtrep, datejorep, minreplib)
-
-        elif current_table == "tam_questions":
+        elif table == "tam_questions":
             # Filter: QE only
-            if _get(fields, current_cols, "natquecod") != "QE":
+            if _get(fields, cols, "natquecod") != "QE":
                 continue
 
             # Filter: legislature 14 onward
-            leg_str = _get(fields, current_cols, "legislature")
+            leg_str = _get(fields, cols, "legislature")
             try:
                 legislature = int(leg_str or "0")
             except ValueError:
@@ -256,7 +255,7 @@ def parse_senat_sql_dump(sql_file: IO[bytes]) -> list[ParsedQuestion]:  # noqa: 
                 continue
 
             # Question number
-            numero_str = _get(fields, current_cols, "numero")
+            numero_str = _get(fields, cols, "numero")
             if not numero_str:
                 continue
             # Strip leading zeros; can be "01380"
@@ -266,31 +265,74 @@ def parse_senat_sql_dump(sql_file: IO[bytes]) -> list[ParsedQuestion]:  # noqa: 
             except ValueError:
                 continue
 
-            internal_id = _get(fields, current_cols, "id") or ""
+            internal_id = _get(fields, cols, "id") or ""
 
             partial.append(
                 _PartialQ(
                     internal_id=internal_id,
                     legislature=legislature,
                     numero=numero,
-                    sorquecod=_get(fields, current_cols, "sorquecod") or "0",
-                    titre=_get(fields, current_cols, "titre"),
-                    nom=_get(fields, current_cols, "nom"),
-                    prenom=_get(fields, current_cols, "prenom"),
-                    codequalite=_get(fields, current_cols, "codequalite"),
-                    circonscription=_get(fields, current_cols, "circonscription"),
-                    groupe=_get(fields, current_cols, "groupe"),
-                    datejodepot=_get(fields, current_cols, "datejodepot"),
-                    mindepotlib=_get(fields, current_cols, "mindepotlib"),
-                    minreplib1=_get(fields, current_cols, "minreplib1"),
-                    datejorep1=_get(fields, current_cols, "datejorep1"),
-                    txtque=_get(fields, current_cols, "txtque") or "",
-                    themes_raw=_get(fields, current_cols, "themes"),
+                    sorquecod=_get(fields, cols, "sorquecod") or "0",
+                    titre=_get(fields, cols, "titre"),
+                    nom=_get(fields, cols, "nom"),
+                    prenom=_get(fields, cols, "prenom"),
+                    codequalite=_get(fields, cols, "codequalite"),
+                    circonscription=_get(fields, cols, "circonscription"),
+                    groupe=_get(fields, cols, "groupe"),
+                    datejodepot=_get(fields, cols, "datejodepot"),
+                    mindepotlib=_get(fields, cols, "mindepotlib"),
+                    minreplib1=_get(fields, cols, "minreplib1"),
+                    datejorep1=_get(fields, cols, "datejorep1"),
+                    txtque=_get(fields, cols, "txtque") or "",
+                    themes_raw=_get(fields, cols, "themes"),
                 )
             )
 
+    return sort_map, theme_map, partial
+
+
+def _parse_responses(
+    open_stream: Callable[[], IO[bytes]], wanted_ids: set[str]
+) -> dict[str, tuple]:
+    """Pass 2: ``tam_reponses`` rows, kept only for ids in *wanted_ids*."""
+    responses: dict[str, tuple] = {}
+    for table, cols, fields in _stream_copy_blocks(open_stream):
+        if table != "tam_reponses":
+            continue
+        idque = _get(fields, cols, "idque")
+        if not idque or idque not in wanted_ids:
+            continue
+        txtrep = _get(fields, cols, "txtrep")
+        datejorep = _get(fields, cols, "datejorep")
+        minreplib = _get(fields, cols, "minreplib")
+        responses[idque] = (txtrep, datejorep, minreplib)
+    return responses
+
+
+def parse_senat_sql_dump(
+    open_stream: Callable[[], IO[bytes]],
+) -> list[ParsedQuestion]:
+    """Parse a Sénat pg_dump file, returning QE questions from leg 14 onward.
+
+    Two passes over the dump, via *open_stream* (called once per pass — the
+    caller must be able to reopen the same underlying file each time):
+      1. ``sortquestion`` → sort_map, ``the`` → theme_map, ``tam_questions``
+         → partial question rows (filtered to QE + leg >= 14).
+      2. ``tam_reponses`` → responses dict, filtered to only the question ids
+         kept in pass 1. Doing this as a second, filtered pass (rather than
+         collecting every response row up front) keeps memory bounded to the
+         legislatures we actually keep, instead of the full 1978-present
+         history the dump covers.
+
+    Question rows are then enriched with response text and resolved theme
+    labels, and converted to ``ParsedQuestion`` objects.
+    """
+    sort_map, theme_map, partial = _parse_lookups_and_questions(open_stream)
+    wanted_ids = {p.internal_id for p in partial}
+    responses = _parse_responses(open_stream, wanted_ids)
+
     logger.debug(
-        "Single-pass done: %d partial questions, %d responses, %d sort codes, %d themes",
+        "Two-pass done: %d partial questions, %d responses, %d sort codes, %d themes",
         len(partial),
         len(responses),
         len(sort_map),
@@ -395,8 +437,7 @@ def ingest_senat_dump(
             )
         sql_name = sql_names[0]
 
-        with zf.open(sql_name) as sql_file:
-            questions = parse_senat_sql_dump(sql_file)
+        questions = parse_senat_sql_dump(lambda: zf.open(sql_name))
 
     logger.info(
         "  %d questions parsed (legislature >= 14, natquecod=QE)", len(questions)

--- a/qe/ingestion_senat.py
+++ b/qe/ingestion_senat.py
@@ -37,7 +37,7 @@ import zipfile
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import IO, Callable, Iterator
+from typing import IO, Callable, Iterator, NamedTuple
 
 from qe.ingestion_an import (
     IngestStats,
@@ -143,6 +143,14 @@ def _resolve_themes(raw: str | None, theme_map: dict[str, str]) -> list[str] | N
 # ---------------------------------------------------------------------------
 # Intermediate structure for buffering a filtered question row
 # ---------------------------------------------------------------------------
+
+
+class _ResponseRow(NamedTuple):
+    """A ``tam_reponses`` row, keyed by ``idque`` in the ``responses`` dict."""
+
+    txtrep: str | None
+    datejorep: str | None
+    minreplib: str | None
 
 
 @dataclass
@@ -293,19 +301,20 @@ def _parse_lookups_and_questions(  # noqa: C901
 
 def _parse_responses(
     open_stream: Callable[[], IO[bytes]], wanted_ids: set[str]
-) -> dict[str, tuple]:
+) -> dict[str, _ResponseRow]:
     """Pass 2: ``tam_reponses`` rows, kept only for ids in *wanted_ids*."""
-    responses: dict[str, tuple] = {}
+    responses: dict[str, _ResponseRow] = {}
     for table, cols, fields in _stream_copy_blocks(open_stream):
         if table != "tam_reponses":
             continue
         idque = _get(fields, cols, "idque")
         if not idque or idque not in wanted_ids:
             continue
-        txtrep = _get(fields, cols, "txtrep")
-        datejorep = _get(fields, cols, "datejorep")
-        minreplib = _get(fields, cols, "minreplib")
-        responses[idque] = (txtrep, datejorep, minreplib)
+        responses[idque] = _ResponseRow(
+            txtrep=_get(fields, cols, "txtrep"),
+            datejorep=_get(fields, cols, "datejorep"),
+            minreplib=_get(fields, cols, "minreplib"),
+        )
     return responses
 
 
@@ -354,9 +363,9 @@ def parse_senat_sql_dump(
         # Response data: prefer tam_reponses (richer), fall back to tam_questions cols
         rep_row = responses.get(p.internal_id)
         if rep_row:
-            txtrep, datejorep_raw, minreplib = rep_row
-            date_rep = _parse_timestamp_as_date(datejorep_raw) or date_rep
-            ministre_reponse = minreplib or p.minreplib1
+            txtrep = rep_row.txtrep
+            date_rep = _parse_timestamp_as_date(rep_row.datejorep) or date_rep
+            ministre_reponse = rep_row.minreplib or p.minreplib1
         else:
             txtrep = None
             ministre_reponse = p.minreplib1 if etat == "REPONDU" else None

--- a/scripts/download_an.py
+++ b/scripts/download_an.py
@@ -32,7 +32,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import hashlib
 import logging
 import sys
 from pathlib import Path
@@ -40,6 +39,7 @@ from pathlib import Path
 import requests
 
 from qe.downloads import download_with_retries
+from qe.hashing import hash_file
 
 logging.basicConfig(
     level=logging.INFO,
@@ -109,7 +109,7 @@ def _ingest(dest_dir: Path, legislatures: list[int]) -> None:
                 "Legislature %d — archive not found, skipping ingest: %s", leg, zip_path
             )
             continue
-        file_hash = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+        file_hash = hash_file(zip_path)
         if manifest.get(str(zip_path)) == file_hash:
             logger.info(
                 "Legislature %d — already ingested (hash unchanged), skipping", leg

--- a/scripts/ingest_an.py
+++ b/scripts/ingest_an.py
@@ -13,7 +13,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import hashlib
 import logging
 import sys
 import zipfile
@@ -21,6 +20,7 @@ from pathlib import Path
 
 from qe import db
 from qe.answer_embedding import try_embed_answers_from_env
+from qe.hashing import hash_file
 from qe.ingestion_an import (
     ingest_an_zip_file,
     parse_an_archive_question_xml,
@@ -121,7 +121,7 @@ def main() -> None:
     manifest = db.get_manifest_entries()
 
     for zip_path in zip_files:
-        file_hash = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+        file_hash = hash_file(zip_path)
         if manifest.get(str(zip_path)) == file_hash:
             logger.info("  %-40s -> already ingested, skipping", zip_path.name)
             continue

--- a/scripts/ingest_senat.py
+++ b/scripts/ingest_senat.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import collections
-import hashlib
 import logging
 import sys
 import zipfile
@@ -24,6 +23,7 @@ from pathlib import Path
 
 from qe import db
 from qe.answer_embedding import try_embed_answers_from_env
+from qe.hashing import hash_file
 from qe.ingestion_senat import ingest_senat_dump, parse_senat_sql_dump
 
 logging.basicConfig(
@@ -47,8 +47,8 @@ def _dry_run(zip_path: Path) -> None:
         if not sql_names:
             logger.error("No .sql file found in %s", zip_path.name)
             return
-        with zf.open(sql_names[0]) as f:
-            questions = parse_senat_sql_dump(f)
+        sql_name = sql_names[0]
+        questions = parse_senat_sql_dump(lambda: zf.open(sql_name))
 
     total = len(questions)
     by_leg: dict[int, int] = collections.Counter(q.legislature for q in questions)
@@ -102,7 +102,7 @@ def main() -> None:
         _dry_run(zip_path)
         return
 
-    file_hash = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+    file_hash = hash_file(zip_path)
     manifest = db.get_manifest_entries()
 
     if not args.force and manifest.get(str(zip_path)) == file_hash:

--- a/tests/test_ingestion_senat_legislature_filter.py
+++ b/tests/test_ingestion_senat_legislature_filter.py
@@ -33,19 +33,19 @@ def _row(legislature: int, numero: str, internal_id: str, txtque: str) -> str:
     )
 
 
-def _build_dump(rows: list[str]) -> io.BytesIO:
+def _build_dump(rows: list[str]) -> bytes:
     lines = [
         f"COPY questions.tam_questions ({_COLUMNS}) FROM stdin;",
         *rows,
         r"\.",
     ]
-    return io.BytesIO(("\n".join(lines) + "\n").encode("utf-8"))
+    return ("\n".join(lines) + "\n").encode("utf-8")
 
 
 def test_drops_questions_before_legislature_14() -> None:
     dump = _build_dump([_row(13, "00100", "1", "Trop ancienne")])
 
-    questions = parse_senat_sql_dump(dump)
+    questions = parse_senat_sql_dump(lambda: io.BytesIO(dump))
 
     assert questions == []
 
@@ -60,6 +60,47 @@ def test_keeps_legislature_beyond_previously_hardcoded_range() -> None:
         ]
     )
 
-    questions = parse_senat_sql_dump(dump)
+    questions = parse_senat_sql_dump(lambda: io.BytesIO(dump))
 
     assert {q.id for q in questions} == {"SENAT-17-QE-200", "SENAT-25-QE-300"}
+
+
+def test_joins_response_text_across_the_two_parsing_passes() -> None:
+    # tam_reponses is parsed in a second pass, filtered to the ids kept from
+    # tam_questions in the first pass — this exercises that the join between
+    # the two passes still lines up correctly.
+    lines = [
+        f"COPY questions.tam_questions ({_COLUMNS}) FROM stdin;",
+        _row(17, "00200", "42", "Question texte"),
+        r"\.",
+        "COPY questions.tam_reponses (idque, txtrep, datejorep, minreplib) FROM stdin;",
+        "42\tRéponse texte\t2023-02-01 00:00:00\tMinistere X",
+        r"\.",
+    ]
+    dump = ("\n".join(lines) + "\n").encode("utf-8")
+
+    questions = parse_senat_sql_dump(lambda: io.BytesIO(dump))
+
+    assert len(questions) == 1
+    assert questions[0].texte_reponse == "Réponse texte"
+    assert questions[0].ministre_reponse_libelle == "Ministere X"
+
+
+def test_response_for_a_filtered_out_question_is_not_joined_elsewhere() -> None:
+    # A response row whose idque belongs to a question dropped in pass 1 must
+    # not leak onto some other, unrelated kept question.
+    lines = [
+        f"COPY questions.tam_questions ({_COLUMNS}) FROM stdin;",
+        _row(13, "00100", "1", "Trop ancienne"),  # dropped: legislature < 14
+        _row(17, "00200", "2", "Question courante"),  # kept, no response
+        r"\.",
+        "COPY questions.tam_reponses (idque, txtrep, datejorep, minreplib) FROM stdin;",
+        "1\tRéponse orpheline\t2023-02-01 00:00:00\tMinistere X",
+        r"\.",
+    ]
+    dump = ("\n".join(lines) + "\n").encode("utf-8")
+
+    questions = parse_senat_sql_dump(lambda: io.BytesIO(dump))
+
+    assert len(questions) == 1
+    assert questions[0].texte_reponse is None


### PR DESCRIPTION
## Summary
- `qe-ingestion` was OOMKilled on most recent runs — traced to two full-file-in-memory patterns.
- `hashlib.sha256(zip_path.read_bytes())` loaded whole archives into memory just to hash them (Sénat's `questions.zip` is ~280 MB compressed) — replaced with streamed hashing (`hashlib.file_digest`).
- `parse_senat_sql_dump` built an unfiltered `tam_reponses` dict for every answer since 1978, regardless of legislature — the dump covers 1978–present but we only keep legislature ≥ 14. Split into two passes: pass 1 filters `tam_questions` and collects the ids we keep, pass 2 only stores `tam_reponses` rows for those ids.

## Test plan
- [x] `poetry run pytest -m "not integration"` — 54 passed
- [x] `poetry run ruff check` / `ruff format --check` / `mypy` clean on all touched files
- [x] Added `test_joins_response_text_across_the_two_parsing_passes` and `test_response_for_a_filtered_out_question_is_not_joined_elsewhere` to guard the pass-1/pass-2 join