### PR TITLE
chore(db): drop des colonnes description de directions/bureaux (+ archive)

### DIFF
--- a/alembic/versions/c8d9e0f1a2b3_drop_org_description_columns.py
+++ b/alembic/versions/c8d9e0f1a2b3_drop_org_description_columns.py
@@ -1,0 +1,66 @@
+"""drop description columns from directions and bureaux
+
+The `description` texts ("Attribuer ici les questions sur…") were
+written for the retired responsibilities-similarity attribution
+feature. Since its removal, no code reads them — the only surface that
+touched them was the admin Organisation page's display/edit form, whose
+help text still (wrongly) claimed they fed the attribution algorithms.
+
+Product call: clean the schema so what remains is what the system
+actually uses. The curated texts are NOT lost — they are archived,
+verbatim, in `docs/perimetres_directions_bureaux.md` (committed
+alongside this migration), available for future reuse such as tooltips
+on the attribution pages.
+
+Also drops `directions_desc_backup`, a one-off safety copy of the
+direction descriptions taken before a past rewrite — superseded by the
+markdown archive.
+
+Deploy order: qe-front must deploy its side FIRST (stop selecting the
+`description` columns in the organisation routes / Drizzle schema),
+otherwise those routes fail with UndefinedColumn once this migration
+runs.
+
+Revision ID: c8d9e0f1a2b3
+Revises: b7c8d9e0f1a2
+Create Date: 2026-08-28 15:10:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d9e0f1a2b3"
+down_revision: Union[str, Sequence[str], None] = "b7c8d9e0f1a2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _columns(bind: sa.engine.Connection, table: str) -> set[str]:
+    return {c["name"] for c in sa.inspect(bind).get_columns(table)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    if "description" in _columns(bind, "directions"):
+        op.drop_column("directions", "description")
+    if "description" in _columns(bind, "bureaux"):
+        op.drop_column("bureaux", "description")
+    op.execute("DROP TABLE IF EXISTS directions_desc_backup")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Columns come back empty — the content lives in
+    # docs/perimetres_directions_bureaux.md and would need a manual
+    # re-import. directions_desc_backup is not recreated (it was itself
+    # a one-off snapshot).
+    bind = op.get_bind()
+    if "description" not in _columns(bind, "directions"):
+        op.add_column("directions", sa.Column("description", sa.Text(), nullable=True))
+    if "description" not in _columns(bind, "bureaux"):
+        op.add_column("bureaux", sa.Column("description", sa.Text(), nullable=True))

--- a/alembic/versions/c8d9e0f1a2b3_drop_org_description_columns.py
+++ b/alembic/versions/c8d9e0f1a2b3_drop_org_description_columns.py
@@ -50,7 +50,8 @@ def upgrade() -> None:
         op.drop_column("directions", "description")
     if "description" in _columns(bind, "bureaux"):
         op.drop_column("bureaux", "description")
-    op.execute("DROP TABLE IF EXISTS directions_desc_backup")
+    if sa.inspect(bind).has_table("directions_desc_backup"):
+        op.drop_table("directions_desc_backup")
 
 
 def downgrade() -> None:

--- a/docs/perimetres_directions_bureaux.md
+++ b/docs/perimetres_directions_bureaux.md
@@ -1,0 +1,323 @@
+# Périmètres des directions et bureaux
+
+Textes « Attribuer ici… » rédigés depuis les documents d'organigramme
+fournis par les directions (DGCS, DSS). Historiquement stockés dans les
+colonnes `description` de `directions` / `bureaux`, supprimées par la
+migration `c8d9e0f1a2b3` : plus aucun code ne les lisait depuis le
+retrait de l'attribution par similarité de responsabilités. Conservés
+ici comme documentation métier — par exemple pour de futurs tooltips
+sur les pages d'attribution.
+
+## Directions
+
+### DAJ
+
+Attribuer ici les questions transversales nécessitant un conseil juridique de niveau ministériel sur les politiques sociales : interprétation et application du droit social, du droit du travail et du droit de la santé ; contentieux administratifs et constitutionnels intéressant les Ministères Sociaux ; transposition de directives européennes ; élaboration de textes législatifs et réglementaires ; questions juridiques sur la protection des données personnelles dans le secteur social.
+
+Mots-clés : conseil juridique - contentieux - droit social - droit du travail - droit de la santé - directive européenne - protection des données - élaboration textes - SGMAS
+
+### DARES
+
+Attribuer ici les questions sur les études, statistiques et données du marché du travail et des politiques d'emploi : statistiques du chômage et de l'emploi ; analyse du marché du travail ; enquêtes statistiques sur les conditions de travail (ACEMO, etc.) ; études sur l'insertion professionnelle, la formation et l'apprentissage ; données sur les écarts de salaires, la précarité, les politiques actives de l'emploi.
+
+Mots-clés : statistiques travail - statistiques chômage - marché du travail - enquête ACEMO - études emploi - données apprentissage - service statistique ministériel - SSM travail
+
+### DFAS
+
+Attribuer ici les questions transversales sur la gestion budgétaire, les achats publics et les fonctions support des Ministères Sociaux : pilotage budgétaire des programmes ministériels ; achats publics et marchés ; services généraux et immobilier ; politique de gestion financière interne ; subventions et exécution budgétaire des programmes sociaux ; relations avec les opérateurs publics.
+
+Mots-clés : pilotage budgétaire - achats publics - marchés - services généraux - immobilier - subventions - programmes ministériels - SGMAS
+
+### DGCS
+
+Attribuer ici les questions sur la cohésion sociale au sens large : politiques de solidarité, prise en charge des personnes vulnérables, médico-social et égalité femmes-hommes. Domaines principaux : minima sociaux (RSA, AAH, ASS, prime d'activité, ASPA) ; protection de l'enfance (ASE, mineurs non accompagnés, lutte contre les violences faites aux enfants, modes d'accueil du jeune enfant, micro-crèches) ; personnes âgées et dépendance (EHPAD, grand âge, aidants familiaux, perte d'autonomie, USLD) ; handicap (personnes handicapées, ESAT, MDPH, PCH, AEEH, accessibilité, insertion professionnelle) ; politique familiale ; aide à domicile et professions du social (TISF, ADV, prime Ségur, revalorisations salariales du secteur médico-social) ; égalité femmes-hommes et lutte contre les violences sexistes et sexuelles ; aide alimentaire et lutte contre la pauvreté.
+
+Mots-clés : AAH - RSA - minima sociaux - EHPAD - aidants - dépendance - protection enfance - ASE - micro-crèches - handicap - ESAT - MDPH - PCH - AEEH - aide à domicile - prime Ségur - médico-social - égalité femmes-hommes - violences conjugales - aide alimentaire - lutte contre la pauvreté
+
+### DGEFP
+
+Attribuer ici les questions sur les politiques publiques de l'emploi, de la formation professionnelle et de l'insertion sur le marché du travail. Domaines principaux : apprentissage et alternance (CFA, financement de l'apprentissage, aides à l'embauche d'apprentis, aides au permis pour apprentis) ; compte personnel de formation (CPF, fraudes, financement, permis de conduire via CPF) ; missions locales et accompagnement des jeunes ; France Travail (anciennement Pôle emploi) ; AFPA et formation professionnelle des adultes ; insertion par l'activité économique (IAE) ; entreprises adaptées, ESAT et insertion professionnelle des personnes handicapées ; indemnisation chômage et cumul ARE/activité ; titres et certifications professionnelles (RNCP, validation des acquis) ; politique du plein emploi (loi du 18 décembre 2023) ; contrats aidés (PEC, CIE) ; plans de sauvegarde de l'emploi (PSE) et restructurations.
+
+Mots-clés : apprentissage - CFA - alternance - CPF - missions locales - France Travail - AFPA - IAE - entreprises adaptées - ESAT - chômage - ARE - RNCP - plein emploi - contrats aidés - PSE - permis de conduire CPF - formation professionnelle - insertion
+
+### DGOS
+
+Attribuer ici les questions sur l'organisation, le financement et le personnel des établissements de santé (hôpitaux publics et privés, cliniques) et l'offre de soins. Domaines principaux : urgences hospitalières, services de soins critiques, organisation territoriale ; formations médicales et paramédicales (étudiants en médecine, internat, quatrième année généraliste, sages-femmes, infirmiers en pratique avancée IPA, assistants dentaires, psychomotriciens) ; statuts et conditions de travail du personnel hospitalier (praticiens hospitaliers, sages-femmes, ambulanciers, perfusionnistes, IPA, prime Ségur, complément de traitement indiciaire) ; démographie médicale et déserts médicaux (médecins libéraux, conventionnement, installation) ; pédopsychiatrie et santé mentale ; pharmacie d'officine (démographie, conventionnement) ; financement et gestion hospitalière (T2A, IFAQ, comptes financiers) ; transports sanitaires ; violences et discriminations dans le milieu médical.
+
+Mots-clés : hôpital - urgences - praticiens hospitaliers - sages-femmes - internes - quatrième année - IPA - démographie médicale - déserts médicaux - pédopsychiatrie - pharmacie d'officine - transports sanitaires - prime Ségur hospitalier - T2A - IFAQ - médecine de ville - statut hospitalier
+
+### DGS
+
+Attribuer ici les questions sur la santé publique, la prévention sanitaire et la sécurité sanitaire. Domaines principaux : vaccination et politique vaccinale (papillomavirus HPV, VRS, covid-19, méningite) ; lutte contre les addictions (tabac, alcool, protoxyde d'azote, drogues, salles de shoot / haltes soins addictions) ; politique nutritionnelle (Nutri-Score, étiquetage alimentaire, qualité nutritionnelle) ; santé environnementale (PFAS, chlorure de vinyle, qualité de l'eau, qualité de l'air, pollution) ; dépistage et prise en charge des maladies rares ou chroniques (Lyme, méningite, mésothéliome) ; gestion des déchets d'activités de soins à risques infectieux (DASRI) ; bioéthique et procréation (don du sang, don d'embryons, AMP, consentement) ; produits de santé sous surveillance (Essure, Androcur, signalements de pharmacovigilance) ; pénuries de médicaments stratégiques et souveraineté sanitaire ; lutte contre les pratiques à risque (jeux d'argent, brûle-graisse, compléments alimentaires).
+
+Mots-clés : vaccination - HPV - papillomavirus - VRS - addictions - protoxyde d'azote - Nutri-Score - alimentation - PFAS - santé environnementale - pollution - eau potable - méningite - Lyme - DASRI - don du sang - AMP - bioéthique - pharmacovigilance - pénurie médicaments - santé publique - prévention
+
+### DGT
+
+Attribuer ici les questions sur le droit du travail, les conditions de travail, la santé au travail et le dialogue social. Domaines principaux : droit du travail individuel (CDD, CDD multi-remplacements, licenciement, inaptitude, congés payés, jurisprudence Cour de cassation) ; droit du travail collectif (CSE, représentativité syndicale et patronale, conventions collectives, accords de branche) ; santé et sécurité au travail (médecine du travail, accidents du travail graves et mortels, canicule, prévention) ; cancers professionnels et amiante ; inspection du travail (effectifs, conditions d'exercice) ; travail dominical et jours fériés (1er mai) ; travail intérimaire et précarité ; travail des plateformes (directive européenne) ; télétravail ; lutte contre les discriminations à l'embauche (algorithmes, IA recruteuse) ; absentéisme et arrêts maladie ; durée du travail ; conditions particulières (intermittents, conducteurs, BTP) ; transposition de directives européennes (transparence salariale, droits sociaux travailleurs plateformes).
+
+Mots-clés : droit du travail - CDD - CDI - licenciement - inaptitude - CSE - représentativité syndicale - médecine du travail - accidents du travail - cancers professionnels - amiante - inspection du travail - travail dominical - intérim - plateformes - télétravail - discriminations - absentéisme - durée du travail - directive européenne
+
+### DIPLP
+
+Attribuer ici les questions sur la stratégie nationale de prévention et de lutte contre la pauvreté, coordonnée à l'échelle interministérielle : pacte d'ambition pour l'insertion ; mesures du Plan Pauvreté ; territoires pauvreté ; suivi des dispositifs anti-pauvreté ; lien avec les conseils départementaux et les politiques locales d'insertion.
+
+Mots-clés : stratégie pauvreté - plan pauvreté - prévention pauvreté - lutte contre la pauvreté - délégation interministérielle - insertion sociale - conseil départemental
+
+### DNS
+
+Attribuer ici les questions sur la stratégie e-santé et le numérique en santé. Domaines principaux : Mon espace santé (espace numérique de santé du patient) ; dossier médical partagé (DMP) ; interopérabilité des SI de santé, identifiant national de santé (INS) ; télémédecine et téléconsultation (cabines de téléconsultation, plateformes externes) ; protection des données de santé personnelles ; éthique et IA dans la santé ; cybersécurité des établissements de santé ; parcours de soins numérique ; ouverture et partage des données de santé.
+
+Mots-clés : Mon espace santé - DMP - télémédecine - téléconsultation - INS - interopérabilité - données de santé - cybersécurité santé - e-santé - parcours numérique
+
+### DREES
+
+Attribuer ici les questions sur les études, statistiques et données du champ santé et social : statistiques sur les minima sociaux et les bénéficiaires (RSA, AAH, ASPA) ; comptes de la santé et dépenses de protection sociale ; études sur les inégalités de santé ; démographie médicale et offre de soins ; statistiques sur les établissements médico-sociaux ; évaluation des politiques publiques sociales et sanitaires.
+
+Mots-clés : statistiques santé - statistiques sociales - minima sociaux - comptes santé - démographie médicale - inégalités santé - évaluation politiques - service statistique ministériel - SSM santé social
+
+### DRH
+
+Attribuer ici les questions sur la gestion des corps de fonctionnaires et les ressources humaines des Ministères Sociaux : statuts des inspecteurs du travail (titularisation, formation INTEFP, conditions d'exercice) ; statuts des médecins et pharmaciens inspecteurs de santé publique ; recrutement, formation et carrière des personnels du ministère ; conditions de travail des agents des administrations centrales et déconcentrées ; gestion des effectifs et politiques RH.
+
+Mots-clés : statut inspecteurs - inspection du travail - INTEFP - médecins inspecteurs santé publique - corps de fonctionnaires - recrutement - formation agents - DRH SGMAS
+
+### DSS
+
+Attribuer ici les questions sur la sécurité sociale et le financement de la protection sociale. Domaines principaux : régimes de retraite de base et complémentaires (réversion, ASPA, cumul emploi-retraite, TUC, carrière longue, sapeurs-pompiers volontaires, RQTH) ; remboursement et tarification des produits de santé (médicaments, génériques, CEPS, ALD, franchises médicales, vaccins, dispositifs médicaux) ; conventionnement des professions de santé libérales et tarification des actes (médecins, kinésithérapeutes, infirmiers, taxis CPAM, radiologues, transports sanitaires) ; pharmacies d'officine et plafonds de remise ; organismes complémentaires (mutuelles, prévoyance) ; cotisations sociales (CSG, RSI, conjoint collaborateur, auto-entrepreneurs, exonérations) ; recouvrement URSSAF ; accidents du travail et maladies professionnelles (AT/MP, FIVA, amiante) ; prestations familiales et aides au logement (CMG, AEEH, allocations familiales) ; lutte contre la fraude sociale.
+
+Mots-clés : retraite - pension de réversion - ASPA - ALD - franchises médicales - médicaments - CEPS - génériques - kinésithérapeutes - infirmiers - taxis conventionnés - mutuelles - complémentaire santé - cotisations sociales - CSG - URSSAF - AT/MP - amiante - FIVA - CMG - AEEH - sécurité sociale - PLFSS - fraude sociale
+
+### Health Data Hub
+
+Attribuer ici les questions spécifiques à la Plateforme des Données de Santé (Health Data Hub), GIP partenaire des Ministères Sociaux : accès et mise à disposition des données de santé pour la recherche ; hébergement des données de santé (Microsoft Azure et alternatives souveraines) ; sécurité et confidentialité des données ; appels à projets data en santé ; gouvernance du Health Data Hub.
+
+Mots-clés : Health Data Hub - HDH - données de santé - hébergement données - souveraineté numérique - GIP - recherche en santé - Microsoft Azure
+
+### SGMAS
+
+Attribuer ici les questions transversales sur l'organisation et la coordination des Ministères Sociaux dans leur ensemble : pilotage global des directions support (DFAS, DRH, DAJ, DNUM, DAEI, DICOM) ; coordination interministérielle ; relations entre administration centrale et services déconcentrés (ARS, DREETS) ; questions ne relevant pas spécifiquement d'une direction métier mais du fonctionnement global du ministère.
+
+Mots-clés : coordination interministérielle - pilotage transverse - ARS - DREETS - administration centrale - services déconcentrés - secrétariat général
+
+## Bureaux
+
+### DGCS
+
+#### [BAEI] Affaires européennes et internationales
+
+Attribuer ici les questions portant sur la dimension européenne ou internationale des politiques sociales de la DGCS : directives européennes, coopération internationale, positions françaises dans les instances européennes et internationales sur les politiques sociales.
+
+Mots-clés : Europe - international - directives européennes - coopération internationale
+
+#### [SD1/1A] Soutien européen à l'aide alimentaire
+
+Attribuer ici les questions portant spécifiquement sur les fonds européens dédiés à l'aide alimentaire (FEAD), les marchés publics d'approvisionnement, les opérations de contrôle France AgriMer et les associations habilitées dans le cadre du dispositif européen.
+
+Mots-clés : FEAD - fonds européens - France AgriMer - associations habilitées
+
+#### [SD1/1B] Accès aux droits, inclusion et lutte contre la précarité alimentaire
+
+Attribuer ici les questions sur l'aide alimentaire nationale (associations caritatives, financement BOP 304, Restos du Coeur, Secours populaire), la pauvreté et la précarité, la domiciliation des personnes sans résidence stable, et l'accès aux droits des personnes en situation d'exclusion.
+
+Mots-clés : aide alimentaire - pauvreté - exclusion sociale - domiciliation - Secours populaire - BOP 304
+
+#### [SD1/1C] Minima sociaux
+
+Attribuer ici les questions sur les minima sociaux : RSA (réforme, solidarité à la source, accompagnement des bénéficiaires), AAH (calcul, cumul avec d'autres revenus), ASS, prime d'activité, et leur financement par les départements.
+
+Mots-clés : RSA - AAH - ASS - minima sociaux - solidarité à la source - départements
+
+#### [SD2/2A] Protection des personnes
+
+Attribuer ici les questions sur la protection juridique des majeurs vulnérables : tutelle, curatelle, sauvegarde de justice, statut et rémunération des mandataires judiciaires (MJPMI), formation et contrôle des mandataires, lutte contre la maltraitance des adultes (plateforme 3977).
+
+Mots-clés : tutelle - curatelle - mandataires judiciaires - majeurs protégés - maltraitance adultes - 3977
+
+#### [SD2/2B] Protection de l'enfance et de l'adolescence
+
+Attribuer ici les questions sur la protection de l'enfance : aide sociale à l'enfance (ASE), enfants confiés, assistants familiaux, mineurs non accompagnés (MNA), adoption, violences et maltraitance faites aux enfants, financement de la protection de l'enfance par les départements.
+
+Mots-clés : ASE - aide sociale à l'enfance - assistants familiaux - MNA - adoption - maltraitance enfants
+
+#### [SD2/2C] Familles et parentalité
+
+Attribuer ici les questions sur la petite enfance et l'accueil du jeune enfant (crèches, micro-crèches, assistantes maternelles, MAM, PSU, PAJE), le soutien à la parentalité, les politiques familiales et la revalorisation salariale des professionnels de la petite enfance.
+
+Mots-clés : crèches - micro-crèches - assistantes maternelles - PSU - PAJE - petite enfance
+
+#### [SD3/3A] Prévention perte d'autonomie et parcours de vie des personnes âgées
+
+Attribuer ici les questions sur le parcours de vie des personnes âgées hors EHPAD : résidences autonomie (MARPA), habitat inclusif et intermédiaire, maisons de vie, offre médico-sociale à domicile, adaptation de la société au vieillissement, Alzheimer.
+
+Mots-clés : résidences autonomie - habitat inclusif - Alzheimer - MARPA - maintien à domicile
+
+#### [SD3/3B] Insertion, citoyenneté et parcours de vie des personnes en situation de handicap
+
+Attribuer ici les questions sur les droits, l'inclusion et l'accompagnement des personnes handicapées : accessibilité, emploi et insertion professionnelle (RQTH, ESAT, emploi accompagné), handicap psychique, transformation de l'offre médico-sociale, numéro 114, chiens guides, résidences de répit, discriminations.
+
+Mots-clés : handicap - accessibilité - MDPH - emploi handicap - ESAT - discrimination
+
+#### [SD3/3C] Droits et aides à la compensation
+
+Attribuer ici les questions sur les aides à la compensation du handicap et de la perte d'autonomie (PCH, APA, CMI), l'accès aux droits et le suivi des MDPH/CDAPH, la gouvernance territoriale des politiques d'autonomie, et l'accueil familial des personnes âgées et handicapées (statut et rémunération des accueillants familiaux).
+
+Mots-clés : PCH - APA - CMI - CDAPH - accueil familial - accueillants familiaux
+
+#### [SD4/4A] Professions sociales
+
+Attribuer ici les questions sur les formations et diplômes du travail social (éducateurs spécialisés, professionnels de la petite enfance), la VAE, la politique de certification, les référentiels de compétences et l'attractivité des métiers du secteur social et médico-social.
+
+Mots-clés : formations - diplômes - VAE - éducateurs spécialisés - attractivité métiers
+
+#### [SD4/4B] Emploi et politique salariale
+
+Attribuer ici les questions sur l'emploi et les conditions salariales dans le secteur social et médico-social : revalorisation salariale (Ségur, extension BASSMS), conventions collectives et procédures d'agrément, politique salariale des branches, financement des ESMS, aides aux postes ESAT, tarification.
+
+Mots-clés : Ségur - financement ESMS - conventions collectives - BASSMS - aides aux postes ESAT - tarification
+
+#### [SD4/4C] Animation territoriale
+
+Attribuer ici les questions sur le contrôle et l'inspection des établissements sociaux et médico-sociaux (ESMS), l'animation du réseau ARS et des services déconcentrés de l'Etat, et les suites de scandales sur la qualité et la sécurité dans les établissements (ex. Orpea).
+
+Mots-clés : contrôle EHPAD - inspection - qualité établissements - Orpea - ARS
+
+#### [SD5/5A] Budgets performance
+
+Attribuer ici les questions sur l'exécution budgétaire des programmes de la DGCS (programmes 304, 157, 137), les crédits alloués aux politiques sociales et les subventions aux associations, ainsi que les questions budgétaires liées aux versements des fonds budgétaires (notamment qui concernent les autres bureaux).
+
+Mots-clés : programme 304 - programme 157 - programme 137 - crédits - subventions
+
+#### [SD5/5B] Gouvernance du secteur social et médico-social
+
+Attribuer ici les questions sur le financement, la gouvernance et la réforme structurelle des ESSMS, notamment des EHPAD : déficits, dotations, modèle de financement, réforme du grand âge, loi cadre sur la dépendance, CPOM, suivi de la dépense médico-sociale, taux d'encadrement.
+
+Mots-clés : EHPAD - grand âge - dépendance - financement EHPAD - loi grand âge - taux encadrement
+
+#### [SDFE/B1] Animation et veille
+
+Attribuer ici les questions sur la politique transversale d'égalité femmes-hommes : coordination interministérielle, financement des associations féministes, lutte contre les discriminations, masculinismes, fiscalité des dons en faveur de la lutte contre les violences, HCEfh.
+
+Mots-clés : égalité F/H - discriminations - masculinisme - HCEfh
+
+#### [SDFE/B2] Egalité entre les femmes et les hommes dans la vie personnelle et sociale
+
+Attribuer ici les questions sur les violences faites aux femmes et les violences intrafamiliales (VIF) : violences conjugales, numéro 3919, pack nouveau départ, ordonnances de protection, mutilations sexuelles féminines, prostitution, centres d'information sur les droits des femmes (CIDFF).
+
+Mots-clés : violences conjugales - VIF - 3919 - pack nouveau départ - ordonnance de protection
+
+#### [SDFE/B3] Egalité entre les femmes et les hommes dans la vie professionnelle
+
+Attribuer ici les questions sur les inégalités professionnelles entre femmes et hommes : écarts de rémunération, index d'égalité professionnelle, santé des femmes au travail (dysménorrhées), entrepreneuriat féminin.
+
+Mots-clés : écarts salariaux - index égalité pro - santé femmes travail - dysménorrhées
+
+### DSS
+
+#### [DACI] Division des affaires communautaires et internationales
+
+Attribuer ici les questions à dimension européenne ou internationale : retraités français à l'étranger, coordination des régimes (frontaliers, polypensionnés), retraités étrangers en France, ressortissants ultramarins (Polynésie), liquidation des dossiers hors de France, fraude aux retraites versées à l'étranger, conventions bilatérales et règlements européens.
+
+Mots-clés : retraités à l'étranger - frontaliers - polypensionnés - règlements européens - coordination internationale - Français hors de France
+
+#### [FRAUDES] Mission de lutte contre la fraude (non présent dans l'organigramme)
+
+Attribuer ici les questions sur la lutte contre la fraude sociale : fraude aux prestations (allocations, retraites), falsifications d'ordonnances, équilibre droits/contrôle, fraudes documentaires et organisées dans le secteur de la protection sociale.
+
+Mots-clés : fraude sociale - fraude aux prestations - falsification ordonnances - lutte contre la fraude
+
+#### [MCGRM] Mission de la coordination et de la gestion du risque maladie
+
+Attribuer ici les questions sur les dispositifs transversaux de gestion du risque maladie : Mon soutien psy, accompagnement post-cancer (loi cancer du sein, décrets d'application), prise en charge de pathologies spécifiques (endométriose, fibrome utérin, hyperacousie/acouphènes, ostéodensitométrie), pertinence des soins et déremboursement.
+
+Mots-clés : Mon soutien psy - cancer du sein - décrets d'application - endométriose - fibrome - hyperacousie - ostéodensitométrie - gestion du risque
+
+#### [SD1A] Établissements de santé et établissements médico-sociaux
+
+Attribuer ici les questions sur les établissements de santé (USLD, hôpitaux) et médico-sociaux (EHPAD, micro-crèches hospitalières), la prise en charge des dispositifs en établissement (capteurs de glucose en EHPAD, PRADO), le transport sanitaire adapté (TPMR), et le modèle économique des pharmacies d'officines.
+
+Mots-clés : EHPAD - USLD - hôpital - capteurs glucose - PRADO - TPMR - pharmacies d'officine
+
+#### [SD1B] Relations avec les professions de santé
+
+Attribuer ici les questions sur les professions de santé libérales et leur convention avec l'Assurance maladie : revalorisations tarifaires (kinésithérapeutes, infirmiers libéraux, orthophonistes), conventionnement (taxis CPAM, radiologues), prises en charge de soins (ostéopathie, cures thermales, contrats responsables, soins externes).
+
+Mots-clés : convention CPAM - revalorisation tarifaire - kinésithérapeutes - infirmiers libéraux - orthophonistes - ostéopathie - cures thermales - taxis conventionnés - radiologie libérale
+
+#### [SD1C] Produits de santé
+
+Attribuer ici les questions sur le remboursement et le prix des produits de santé : médicaments génériques (CEPS, baisses de prix), aides auditives 100 % santé, vaccins (VRS), protections menstruelles, dispositifs médicaux, ALD, franchises médicales, SMR.
+
+Mots-clés : médicaments - génériques - CEPS - vaccins - 100 % santé - protections menstruelles - ALD - franchises - SMR
+
+#### [SD2A] Accès aux soins et prestations de santé
+
+Attribuer ici les questions sur l'accès aux soins et la couverture santé : articulation Sécurité sociale / complémentaires (100 % Sécu, contrats responsables), prestations en espèces (congé maternité, congé parental, pension d'invalidité), participations forfaitaires et franchises médicales, prise en charge de pathologies spécifiques.
+
+Mots-clés : complémentaires santé - 100 % Sécu - congé maternité - congé parental - prime d'activité - participation forfaitaire - couverture santé
+
+#### [SD2B] Prestations familiales et aides au logement
+
+Attribuer ici les questions sur les prestations familiales servies par les CAF : CMG (réforme, modes de garde), AEEH (allocation d'éducation enfant handicapé), AJPP, allocations familiales, micro-crèches (PSU/PAJE), politique familiale et natalité.
+
+Mots-clés : CMG - AEEH - AJPP - allocations familiales - micro-crèches - PSU - PAJE - CAF - politique familiale
+
+#### [SD2C] Accidents du travail et maladies professionnelles
+
+Attribuer ici les questions sur les AT/MP : indemnisation des victimes (amiante / FIVA, décret « aller-vers »), reconnaissance des maladies professionnelles (cancers liés à l'exposition, dérives arrêts maladie), inaptitude en TPE/PME, lutte contre le non-recours.
+
+Mots-clés : AT/MP - amiante - FIVA - aller-vers - maladie professionnelle - inaptitude - non-recours
+
+#### [SD3A] Régimes de retraite de base
+
+Attribuer ici les questions sur les régimes de retraite de base : pension de réversion (déconjugalisation, ex-conjoints divorcés), cumul emploi-retraite, retraite anticipée (carrière longue, RQTH, TUC), ASPA, droits ultramarins, coordination inter-caisses.
+
+Mots-clés : pension de réversion - cumul emploi-retraite - ASPA - RQTH - TUC - carrière longue - retraite anticipée
+
+#### [SD3B] Régimes spéciaux
+
+Attribuer ici les questions sur les régimes spéciaux de retraite et de protection sociale : CNRACL, fonction publique, marins, régimes professionnels particuliers, application des réformes (pouvoir d'achat) aux régimes spéciaux, articulation entre régimes.
+
+Mots-clés : régime spécial - CNRACL - fonction publique - marins - cumul Carat - trimestres orphelins
+
+#### [SD3C] Régimes professionnels de retraites et institutions de protection sociale complémentaire
+
+Attribuer ici les questions sur les organismes complémentaires (mutuelles, assurances santé, prévoyance) : tarification (gel des cotisations, hausses 2026), contribution exceptionnelle, portabilité de la complémentaire d'entreprise, prestations de prévoyance, application de la LFSS aux complémentaires.
+
+Mots-clés : mutuelles - complémentaire santé - cotisations - gel des tarifs - portabilité - prévoyance - contribution exceptionnelle
+
+#### [SD4A] Pilotage budgétaire et performance des organismes de sécurité sociale
+
+Attribuer ici les questions sur les moyens et la performance des organismes de sécurité sociale : conventions d'objectifs et de gestion (COG MSA, CPAM), retards de traitement (CAF, CARSAT pensions de réversion), accompagnement des publics, plateformes de communication.
+
+Mots-clés : COG - CARSAT - CAF - MSA - délais de traitement - retards - performance
+
+#### [SD4B] Gouvernance et performance sociale des organismes de sécurité sociale
+
+Attribuer ici les questions sur les personnels et la gouvernance des organismes de sécurité sociale : conditions salariales des travailleurs sociaux (CAF, CARSAT, MSA), prime Ségur, classification des salaires régime général, mandats sociaux dans les CARSAT, service du contrôle médical.
+
+Mots-clés : travailleurs sociaux - prime Ségur - mandats sociaux - contrôle médical - classification salariale - CARSAT - MSA
+
+#### [SD4C] Systèmes d'information des organismes de sécurité sociale et réglementation des traitements de données à caractère personnel
+
+Attribuer ici les questions sur les SI de la sécurité sociale et la protection des données : Mon espace santé, échanges de données entre caisses (CNAV / organismes étrangers), traçabilité interrégionale du parcours de soins, utilisation de l'IA pour les contrôles URSSAF, plateformes externes (BetterHelp).
+
+Mots-clés : Mon espace santé - SI sécurité sociale - données personnelles - CNAV échanges - IA contrôles - URSSAF
+
+#### [SD5B] Législation financière sociale et fiscale
+
+Attribuer ici les questions sur les cotisations sociales, exonérations et fiscalité spécifique : conjoint collaborateur (statut, cotisations), ACRE (artistes-auteurs), CSG (retraités, hausse 2026), exonérations cotisations patronales (aide à domicile), fiscalité des complémentaires santé, régimes des indépendants et micro-entrepreneurs.
+
+Mots-clés : cotisations sociales - CSG - exonérations - conjoint collaborateur - ACRE - micro-entrepreneur - taxe complémentaires santé
+
+#### [SD5C] Recouvrement
+
+Attribuer ici les questions sur le recouvrement des cotisations (URSSAF) et les dispositifs spécifiques : avance immédiate du crédit d'impôt services à la personne (APA, aide à domicile), chèque-emploi associatif, caisses de congés BTP, impayés de salaires (assistantes maternelles), RSI (rapports).
+
+Mots-clés : URSSAF - recouvrement - crédit d'impôt SAP - avance immédiate - chèque-emploi associatif - caisses de congés BTP - RSI - assistantes maternelles
+
+#### [SD6A] Prévision et analyse des comptes
+
+Attribuer ici les questions sur les prévisions financières et l'analyse des comptes de la sécurité sociale : projections macroéconomiques, soldes des régimes, équilibre financier des branches, rapports annexés au PLFSS.
+
+Mots-clés : comptes de la sécurité sociale - prévision - PLFSS - équilibre financier - branches


### PR DESCRIPTION
## Décision produit

Les textes « Attribuer ici les questions sur… » des colonnes \`description\` de \`directions\` et \`bureaux\` avaient été rédigés pour l'attribution par similarité de responsabilités, retirée par #55. Depuis, **plus aucun code ne les lit** — la seule surface qui les touchait était le formulaire de la page admin Organisation, dont l'aide prétendait encore (à tort) qu'ils « nourrissaient les algorithmes d'attribution ».

Objectif ménage : le schéma ne garde que ce que le système utilise réellement.

## Contenu

1. **\`docs/perimetres_directions_bureaux.md\`** — archive verbatim des 51 textes (15 directions + 36 bureaux, mots-clés compris). Le savoir métier issu des organigrammes DGCS/DSS reste versionné et réutilisable (tooltips d'attribution futurs, par ex.).
2. **Migration \`c8d9e0f1a2b3\`** (chaînée sur \`b7c8d9e0f1a2\`, PR #61) :
   - drop \`directions.description\` + \`bureaux.description\` (guards idempotents)
   - drop \`directions_desc_backup\` (snapshot ponctuel, remplacé par l'archive)
   - \`downgrade()\` recrée les colonnes vides (contenu = l'archive markdown)

## ⚠️ Ordre de déploiement

Le PR qe-front [#119] doit être **déployé AVANT** cette migration : il retire les colonnes du schéma Drizzle et des routes organisation. Sinon \`GET /api/organisation/*\` tombe en \`UndefinedColumn\`.

Chaîne : #59 → #61 → celui-ci (base), et côté front #118 → #119 d'abord.

## Test plan

- [x] Archive générée depuis la base réelle (15 + 36 textes, vérifiée à la main)
- [x] \`ruff check\` OK
- [ ] \`alembic upgrade head\` local après merge qe-front → routes organisation OK sans description
- [x] \`downgrade\` → colonnes recréées vides

🤖 Generated with [Claude Code](https://claude.com/claude-code)