### PR TITLE
fix(db): harden init_schema downgrade with IF EXISTS on Auth.js tables

### DIFF
--- a/alembic/versions/62ff467c436e_init_schema.py
+++ b/alembic/versions/62ff467c436e_init_schema.py
@@ -623,10 +623,11 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Downgrade schema."""
 
-    # IF EXISTS: b2c3d4e5f6a7's downgrade already drops these four Auth.js
-    # tables (it recreates/drops them idempotently for pre-squash databases),
-    # so by the time a full `downgrade base` reaches this migration they're
-    # already gone.
+    # IF EXISTS: a later migration in the downgrade chain (currently
+    # b2c3d4e5f6a7) already drops these four Auth.js tables before this
+    # base migration runs, so they may already be gone. IF EXISTS makes
+    # this downgrade idempotent regardless of which intermediate
+    # migrations have executed.
     op.execute('DROP TABLE IF EXISTS "verificationTokens"')
     op.execute('DROP TABLE IF EXISTS "sessions"')
     op.execute('DROP TABLE IF EXISTS "accounts"')

--- a/alembic/versions/62ff467c436e_init_schema.py
+++ b/alembic/versions/62ff467c436e_init_schema.py
@@ -623,10 +623,14 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Downgrade schema."""
 
-    op.drop_table("verificationTokens")
-    op.drop_table("sessions")
-    op.drop_table("accounts")
-    op.drop_table("users")
+    # IF EXISTS: b2c3d4e5f6a7's downgrade already drops these four Auth.js
+    # tables (it recreates/drops them idempotently for pre-squash databases),
+    # so by the time a full `downgrade base` reaches this migration they're
+    # already gone.
+    op.execute('DROP TABLE IF EXISTS "verificationTokens"')
+    op.execute('DROP TABLE IF EXISTS "sessions"')
+    op.execute('DROP TABLE IF EXISTS "accounts"')
+    op.execute('DROP TABLE IF EXISTS "users"')
     op.drop_table("app_settings")
     op.drop_index(
         "correction_feedback_created_at_idx", table_name="correction_feedback"


### PR DESCRIPTION
## Summary
- `alembic downgrade base` crashed with `UndefinedTable: "verificationTokens"` — `b2c3d4e5f6a7`'s downgrade already idempotently drops the four Auth.js tables (`verificationTokens`, `sessions`, `accounts`, `users`), and it runs before `62ff467c436e`'s (init schema) downgrade in the reverse chain, so those tables are already gone by the time init schema tries to drop them unconditionally.
- Switched those four drops in `62ff467c436e_init_schema.py` to `DROP TABLE IF EXISTS`, matching the idempotent-downgrade pattern already used elsewhere in this migration history.

## Test plan
- [x] On a disposable scratch database: `alembic upgrade head` from empty → succeeds (all revisions, including the merge point)
- [x] `alembic downgrade base` from head → now succeeds, leaves only `alembic_version`
- [x] `alembic upgrade head` again → succeeds cleanly from empty
- [x] `alembic heads` → single head, no diverged branches